### PR TITLE
Add fourteen unlimited-play minigames

### DIFF
--- a/GAMES_BACKLOG.md
+++ b/GAMES_BACKLOG.md
@@ -1,0 +1,53 @@
+# Minigames backlog
+
+The games section is built on an **unlimited-play, no-lockout** model: every
+game is seedable and/or endlessly replayable — no daily cap. This file tracks
+ideas we've discussed but not yet built, so they aren't lost.
+
+Each new game follows the same shape as the existing ones:
+
+- Pure, unit-tested logic in `src/services/<game>.ts` (`<game>.spec.ts`).
+- A `src/views/<Game>View.vue` using the shared `GameToolbar` and, for boards,
+  `useSquareFit` + a URL seed via `src/services/seed.ts`.
+- A route in `src/router/index.js` (`meta: { gamePage: true, lockScroll: true }`)
+  and a card in `src/views/GamesView.vue`.
+
+## Shortlisted (discussed, not yet built)
+
+_None outstanding from the first round — 2048, Tetris, Sudoku, Nonogram, Tango,
+Nerdle, Memory/Simon, and Connect 4 all shipped. New ideas below._
+
+## Arcade concepts to explore
+
+Fast, one-more-go arcade games (the kind that are satisfying to replay), sketched
+from games David enjoyed:
+
+- **Ninja wall-jump** — climb upward between two walls, kicking side to side;
+  avoid spikes. A **long press jumps higher** than a tap. Endless vertical climb,
+  score = height.
+- **Ball bounce** — bounce a ball up a tower of ascending platforms; timing/aim
+  based, don't fall.
+- **Vertical tunnel flapper** — fly upward through a narrowing tunnel; tap the
+  **left or right side** to flap in that direction, no tap = fall. Avoid the
+  walls. (Flappy-Bird-like but vertical and two-sided.)
+- **Mini golf** — aim-and-power putting across a series of holes with obstacles;
+  par per hole, seedable courses.
+- **Color-from-memory** — shown a target color briefly, then recreate it from
+  memory with RGB/HSL sliders; scored by perceptual distance to the target.
+- **Count-the-blocks memory** — Tetris-like shapes slide across the screen; after
+  they pass, recall **how many** there were (or how many of a given type). Speed
+  and count ramp up.
+
+## Other candidates
+
+- **Connections** — sort 16 words into 4 hidden groups, auto-generated from the
+  existing word lists so it never runs out.
+- **Spelling Bee** — make as many words as possible from 7 letters (one required),
+  reusing the word lists.
+- **Letter Boxed** — chain words around a square of 12 letters.
+
+## Known follow-ups on shipped games
+
+- **Nonogram** generation is random-fill (~55%), so puzzles can be ambiguous and
+  aren't curated pictures. Improve with a real nonogram solver (for uniqueness)
+  and/or a library of hand-designed picture bitmaps.

--- a/GAMES_BACKLOG.md
+++ b/GAMES_BACKLOG.md
@@ -17,28 +17,23 @@ Each new game follows the same shape as the existing ones:
 _None outstanding from the first round — 2048, Tetris, Sudoku, Nonogram, Tango,
 Nerdle, Memory/Simon, and Connect 4 all shipped. New ideas below._
 
-## Arcade concepts to explore
+## Arcade concepts — all built ✅
 
-Fast, one-more-go arcade games (the kind that are satisfying to replay), sketched
-from games David enjoyed:
+These were David's own ideas from games he enjoyed. All six shipped:
 
-- **Ninja wall-jump** — climb upward between two walls, kicking side to side;
-  avoid spikes. A **long press jumps higher** than a tap. Endless vertical climb,
-  score = height.
-- **Ball bounce** — bounce a ball up a tower of ascending platforms; timing/aim
-  based, don't fall.
-- **Vertical tunnel flapper** — fly upward through a narrowing tunnel; tap the
-  **left or right side** to flap in that direction, no tap = fall. Avoid the
-  walls. (Flappy-Bird-like but vertical and two-sided.)
-- **Mini golf** — aim-and-power putting across a series of holes with obstacles;
-  par per hole, seedable courses.
-- **Color-from-memory** — shown a target color briefly, then recreate it from
-  memory with RGB/HSL sliders; scored by perceptual distance to the target.
-- **Count-the-blocks memory** — Tetris-like shapes slide across the screen; after
-  they pass, recall **how many** there were (or how many of a given type). Speed
-  and count ramp up.
+- **Ninja wall-jump** → **Ninja Climb** (`/ninja-climb`) — hold to charge, longer =
+  higher; spikes + rising lava.
+- **Ball bounce** → **Ball Bounce** (`/ball-bounce`) — doodle-jump auto-bouncer,
+  steer with screen wrap.
+- **Vertical tunnel flapper** → **Vertical Tunnel** (`/tunnel`) — tap left/right to
+  flap that way; narrowing course.
+- **Mini golf** → **Mini Golf** (`/mini-golf`) — 9 seeded holes, pull-back-to-putt.
+- **Color-from-memory** → **Color from Memory** (`/color-memory`) — recreate a
+  flashed color; perceptual scoring.
+- **Count-the-blocks memory** → **Count the Blocks** (`/count-blocks`) — tally the
+  shapes that streamed past; levels up.
 
-## Other candidates
+## Other candidates (not yet built)
 
 - **Connections** — sort 16 words into 4 hidden groups, auto-generated from the
   existing word lists so it never runs out.
@@ -51,3 +46,6 @@ from games David enjoyed:
 - **Nonogram** generation is random-fill (~55%), so puzzles can be ambiguous and
   aren't curated pictures. Improve with a real nonogram solver (for uniqueness)
   and/or a library of hand-designed picture bitmaps.
+- **Mini Golf** hole layouts are random walls with no solvability check, so a rare
+  combination could be very hard or effectively blocked (and there's no skip). Add
+  a pathfinding/solvability check or curated layouts.

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -73,6 +73,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/sudoku/:seed?',
+      name: 'sudoku',
+      component: () => import('../views/SudokuView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -115,6 +115,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/tunnel',
+      name: 'tunnel',
+      component: () => import('../views/TunnelView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -85,6 +85,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/tango/:seed?',
+      name: 'tango',
+      component: () => import('../views/TangoView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -37,6 +37,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/2048',
+      name: '2048',
+      component: () => import('../views/Game2048View.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/snake',
       name: 'snake',
       component: () => import('../views/SnakeView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -103,6 +103,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/connect-4',
+      name: 'connect-4',
+      component: () => import('../views/Connect4View.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -139,6 +139,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/mini-golf/:seed?',
+      name: 'mini-golf',
+      component: () => import('../views/MiniGolfView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -133,6 +133,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/count-blocks',
+      name: 'count-blocks',
+      component: () => import('../views/CountBlocksView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -79,6 +79,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/nonogram/:seed?',
+      name: 'nonogram',
+      component: () => import('../views/NonogramView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -127,6 +127,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/ball-bounce',
+      name: 'ball-bounce',
+      component: () => import('../views/BallBounceView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -121,6 +121,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/ninja-climb',
+      name: 'ninja-climb',
+      component: () => import('../views/WallJumpView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -91,6 +91,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/nerdle/:seed?',
+      name: 'nerdle',
+      component: () => import('../views/NerdleView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -97,6 +97,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/memory',
+      name: 'memory',
+      component: () => import('../views/MemoryView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -43,6 +43,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/tetris',
+      name: 'tetris',
+      component: () => import('../views/TetrisView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/snake',
       name: 'snake',
       component: () => import('../views/SnakeView.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -109,6 +109,12 @@ const router = createRouter({
       meta: { gamePage: true, lockScroll: true },
     },
     {
+      path: '/color-memory',
+      name: 'color-memory',
+      component: () => import('../views/ColorMemoryView.vue'),
+      meta: { gamePage: true, lockScroll: true },
+    },
+    {
       path: '/wizard-chess/:seed?',
       name: 'wizard-chess',
       component: () => import('../views/WizardChessView.vue'),

--- a/src/services/ballBounce.spec.ts
+++ b/src/services/ballBounce.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BALL_RADIUS,
+  BOUNCE_VY,
+  PLATFORM_SPACING,
+  type Ball,
+  type Platform,
+  nearestPlatformIndex,
+  platformAt,
+  stepBall,
+  tryBounce,
+  wrapDist,
+} from './ballBounce'
+
+describe('stepBall', () => {
+  it('applies gravity (vy decreases) and steers horizontally', () => {
+    const next = stepBall({ x: 0.5, y: 5, vx: 0, vy: 2 }, 1, 16)
+    expect(next.vy).toBeLessThan(2)
+    expect(next.x).toBeGreaterThan(0.5)
+  })
+  it('wraps horizontally past the edges', () => {
+    expect(stepBall({ x: 0.99, y: 0, vx: 0, vy: 0 }, 1, 100).x).toBeLessThan(0.5)
+    expect(stepBall({ x: 0.01, y: 0, vx: 0, vy: 0 }, -1, 100).x).toBeGreaterThan(0.5)
+  })
+})
+
+describe('wrapDist', () => {
+  it('measures the shorter way around', () => {
+    expect(wrapDist(0.1, 0.2)).toBeCloseTo(0.1)
+    expect(wrapDist(0.05, 0.95)).toBeCloseTo(0.1) // across the seam
+  })
+})
+
+describe('tryBounce', () => {
+  const plat: Platform = { x: 0.5, y: 10, width: 0.26 }
+  it('bounces a falling ball that crosses the platform top', () => {
+    const ball: Ball = { x: 0.5, y: 9.98, vx: 0, vy: -3 }
+    const bounced = tryBounce(ball, 10.05, plat)
+    expect(bounced).not.toBeNull()
+    expect(bounced!.vy).toBe(BOUNCE_VY)
+  })
+  it('does not bounce while moving up', () => {
+    expect(tryBounce({ x: 0.5, y: 10, vx: 0, vy: 3 }, 9.9, plat)).toBeNull()
+  })
+  it('does not bounce when horizontally off the platform', () => {
+    const ball: Ball = { x: 0.9, y: 9.98, vx: 0, vy: -3 }
+    expect(tryBounce(ball, 10.05, plat)).toBeNull()
+  })
+  it('does not bounce without crossing the surface (no tunneling false-positive)', () => {
+    // Ball already well below the platform and staying below.
+    const ball: Ball = { x: 0.5, y: 8, vx: 0, vy: -3 }
+    expect(tryBounce(ball, 8.1, plat)).toBeNull()
+  })
+  it('catches a fast fall that would tunnel through in one step', () => {
+    // prevY above, ball now below surface by more than a radius — still bounces
+    // because it crossed the surface this step.
+    const ball: Ball = { x: 0.5, y: 9.9, vx: 0, vy: -30 }
+    expect(tryBounce(ball, 10.4, plat)).not.toBeNull()
+  })
+})
+
+describe('platformAt', () => {
+  it('is deterministic and in-bounds', () => {
+    for (let i = 0; i < 200; i += 1) {
+      const p = platformAt(42, i)
+      expect(platformAt(42, i)).toEqual(p)
+      expect(p.x - p.width / 2).toBeGreaterThanOrEqual(0)
+      expect(p.x + p.width / 2).toBeLessThanOrEqual(1)
+      expect(p.y).toBeCloseTo(i * PLATFORM_SPACING)
+    }
+  })
+})
+
+describe('nearestPlatformIndex', () => {
+  it('rounds y to the closest platform index', () => {
+    expect(nearestPlatformIndex(0)).toBe(0)
+    expect(nearestPlatformIndex(PLATFORM_SPACING * 3 + 0.1)).toBe(3)
+  })
+})
+
+describe('BALL_RADIUS sanity', () => {
+  it('is small enough to fit between platforms', () => {
+    expect(BALL_RADIUS * 2).toBeLessThan(PLATFORM_SPACING)
+  })
+})

--- a/src/services/ballBounce.spec.ts
+++ b/src/services/ballBounce.spec.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import {
   BALL_RADIUS,
+  BASE_SPACING,
   BOUNCE_VY,
-  PLATFORM_SPACING,
+  GRAVITY,
+  MAX_BOUNCES,
+  MAX_SPACING,
   type Ball,
   type Platform,
+  bounceReach,
   nearestPlatformIndex,
   platformAt,
+  platformBroken,
+  platformY,
+  spacingBefore,
   stepBall,
   tryBounce,
   wrapDist,
@@ -31,55 +38,121 @@ describe('wrapDist', () => {
   })
 })
 
-describe('tryBounce', () => {
+describe('tryBounce (top-surface only)', () => {
   const plat: Platform = { x: 0.5, y: 10, width: 0.26 }
-  it('bounces a falling ball that crosses the platform top', () => {
+  it('bounces a falling ball that lands on the platform top', () => {
     const ball: Ball = { x: 0.5, y: 9.98, vx: 0, vy: -3 }
     const bounced = tryBounce(ball, 10.05, plat)
     expect(bounced).not.toBeNull()
     expect(bounced!.vy).toBe(BOUNCE_VY)
+    expect(bounced!.y).toBeCloseTo(plat.y + BALL_RADIUS) // seated on the surface
   })
-  it('does not bounce while moving up', () => {
+  it('does not bounce while moving up (rising through from below)', () => {
     expect(tryBounce({ x: 0.5, y: 10, vx: 0, vy: 3 }, 9.9, plat)).toBeNull()
   })
-  it('does not bounce when horizontally off the platform', () => {
+  it('does not bounce when horizontally off the platform (no side bounce)', () => {
     const ball: Ball = { x: 0.9, y: 9.98, vx: 0, vy: -3 }
     expect(tryBounce(ball, 10.05, plat)).toBeNull()
   })
-  it('does not bounce without crossing the surface (no tunneling false-positive)', () => {
-    // Ball already well below the platform and staying below.
+  it('does not bounce from underneath: falling while already below the surface', () => {
+    // Ball started below the surface and stays below — never crossed the top.
     const ball: Ball = { x: 0.5, y: 8, vx: 0, vy: -3 }
     expect(tryBounce(ball, 8.1, plat)).toBeNull()
   })
   it('catches a fast fall that would tunnel through in one step', () => {
-    // prevY above, ball now below surface by more than a radius — still bounces
-    // because it crossed the surface this step.
     const ball: Ball = { x: 0.5, y: 9.9, vx: 0, vy: -30 }
     expect(tryBounce(ball, 10.4, plat)).not.toBeNull()
   })
 })
 
+describe('bounce reach (climbing is reliable)', () => {
+  it('overshoots the widest shelf gap so the next shelf is always reachable', () => {
+    // A bounce must rise higher than the largest spacing, or you could never
+    // land on the shelf above.
+    expect(bounceReach()).toBeGreaterThan(MAX_SPACING)
+  })
+  it('bounceReach equals v^2 / 2g', () => {
+    expect(bounceReach()).toBeCloseTo((BOUNCE_VY * BOUNCE_VY) / (2 * GRAVITY))
+  })
+  it('simulating a real bounce peaks above the max spacing', () => {
+    let ball: Ball = { x: 0.5, y: 0, vx: 0, vy: BOUNCE_VY }
+    let peak = ball.y
+    for (let i = 0; i < 400 && ball.vy > 0; i += 1) {
+      ball = stepBall(ball, 0, 16)
+      if (ball.y > peak) peak = ball.y
+    }
+    expect(peak).toBeGreaterThan(MAX_SPACING)
+  })
+})
+
+describe('spacing ramp (difficulty increases with height)', () => {
+  it('shelves get further apart as you climb, up to a cap', () => {
+    expect(spacingBefore(1)).toBeCloseTo(BASE_SPACING)
+    expect(spacingBefore(5)).toBeGreaterThan(spacingBefore(1))
+    expect(spacingBefore(50)).toBeGreaterThan(spacingBefore(5))
+    // Never exceeds the cap (and the cap stays below the bounce reach).
+    expect(spacingBefore(500)).toBeCloseTo(MAX_SPACING)
+    expect(MAX_SPACING).toBeLessThan(bounceReach())
+  })
+  it('platformY is strictly increasing and matches accumulated spacing', () => {
+    expect(platformY(0)).toBe(0)
+    let acc = 0
+    for (let i = 1; i < 200; i += 1) {
+      acc += spacingBefore(i)
+      expect(platformY(i)).toBeGreaterThan(platformY(i - 1))
+      expect(platformY(i) - platformY(i - 1)).toBeCloseTo(spacingBefore(i))
+      expect(platformY(i)).toBeCloseTo(acc)
+    }
+  })
+})
+
 describe('platformAt', () => {
-  it('is deterministic and in-bounds', () => {
+  it('is deterministic, in-bounds, and follows platformY', () => {
     for (let i = 0; i < 200; i += 1) {
       const p = platformAt(42, i)
       expect(platformAt(42, i)).toEqual(p)
       expect(p.x - p.width / 2).toBeGreaterThanOrEqual(0)
       expect(p.x + p.width / 2).toBeLessThanOrEqual(1)
-      expect(p.y).toBeCloseTo(i * PLATFORM_SPACING)
+      expect(p.y).toBeCloseTo(platformY(i))
     }
   })
 })
 
 describe('nearestPlatformIndex', () => {
-  it('rounds y to the closest platform index', () => {
-    expect(nearestPlatformIndex(0)).toBe(0)
-    expect(nearestPlatformIndex(PLATFORM_SPACING * 3 + 0.1)).toBe(3)
+  it('inverts platformY (round-trips shelf indices)', () => {
+    for (const i of [0, 1, 2, 5, 13, 14, 30, 100]) {
+      expect(nearestPlatformIndex(platformY(i))).toBe(i)
+    }
+  })
+  it('never returns a negative index', () => {
+    expect(nearestPlatformIndex(-5)).toBe(0)
+  })
+})
+
+describe('platformBroken (shelves vanish after a couple of bounces)', () => {
+  it('breaks once bounced MAX_BOUNCES times', () => {
+    expect(MAX_BOUNCES).toBe(2)
+    expect(platformBroken(0)).toBe(false)
+    expect(platformBroken(1)).toBe(false)
+    expect(platformBroken(2)).toBe(true)
+    expect(platformBroken(3)).toBe(true)
+  })
+  it('a shelf you keep landing on breaks after MAX_BOUNCES bounces', () => {
+    // Mirrors the view: count bounces per shelf and stop once broken.
+    let count = 0
+    const bounceOnce = () => {
+      if (platformBroken(count)) return false // gone — cannot bounce again
+      count += 1
+      return true
+    }
+    for (let i = 0; i < MAX_BOUNCES; i += 1) expect(bounceOnce()).toBe(true)
+    expect(platformBroken(count)).toBe(true)
+    expect(bounceOnce()).toBe(false) // no infinite bouncing on one shelf
   })
 })
 
 describe('BALL_RADIUS sanity', () => {
-  it('is small enough to fit between platforms', () => {
-    expect(BALL_RADIUS * 2).toBeLessThan(PLATFORM_SPACING)
+  it('is small enough to fit between shelves', () => {
+    expect(BALL_RADIUS * 2).toBeLessThan(BASE_SPACING)
   })
 })

--- a/src/services/ballBounce.ts
+++ b/src/services/ballBounce.ts
@@ -1,8 +1,15 @@
 /**
  * Ball Bounce — a doodle-jump-style climber. The ball is always falling under
- * gravity; landing on a platform (only while moving downward) bounces it back
- * up. You steer left/right (with screen wrap). Physics and deterministic,
- * endless platform generation are pure and testable.
+ * gravity; landing on the TOP of a shelf (only while moving downward) bounces it
+ * back up. You steer left/right (with screen wrap). Physics and deterministic,
+ * endless shelf generation are pure and testable.
+ *
+ * Design rules baked in here (see the spec):
+ *  - The bounce clearly overshoots the next shelf so climbing is reliable.
+ *  - Shelves are spaced FURTHER apart the higher you climb (difficulty ramp),
+ *    but never further than the bounce can reach.
+ *  - A shelf breaks (vanishes) after MAX_BOUNCES bounces — no bouncing forever
+ *    on one shelf.
  *
  * Coordinates: x in [0,1] (wraps), y in climb units that only trend upward.
  * The view scales to pixels; velocities are per second.
@@ -24,11 +31,25 @@ export interface Platform {
 }
 
 export const GRAVITY = 9 // climb units / s^2
-export const BOUNCE_VY = 4.6 // upward speed on a bounce
-export const MOVE_VX = 0.75 // horizontal speed from steering input
+export const BOUNCE_VY = 7.4 // upward speed on a bounce (reaches well past MAX_SPACING)
+export const MOVE_VX = 0.85 // horizontal speed from steering input
 export const BALL_RADIUS = 0.035
-export const PLATFORM_SPACING = 0.72 // vertical gap between platforms (units)
+
+// Shelf spacing ramps from BASE_SPACING up to MAX_SPACING as you climb.
+export const BASE_SPACING = 1.5 // gap between the first shelves (units)
+export const MAX_SPACING = 2.3 // gap the ramp tops out at (kept below the bounce reach)
+export const SPACING_RAMP = 0.06 // extra gap added per shelf index until capped
 export const PLATFORM_WIDTH = 0.26
+
+/** A shelf disappears once it has been bounced on this many times. */
+export const MAX_BOUNCES = 2
+
+// Index at which the spacing ramp hits (and then holds at) MAX_SPACING.
+const RAMP_CAP_INDEX =
+  SPACING_RAMP > 0 ? Math.floor((MAX_SPACING - BASE_SPACING) / SPACING_RAMP) + 1 : Number.POSITIVE_INFINITY
+
+/** Highest point a fresh bounce reaches (v^2 / 2g). Must exceed MAX_SPACING. */
+export const bounceReach = (): number => (BOUNCE_VY * BOUNCE_VY) / (2 * GRAVITY)
 
 /** Advance the ball. `steer` is -1/0/1; screen wraps horizontally. */
 export function stepBall(ball: Ball, steer: -1 | 0 | 1, dtMs: number): Ball {
@@ -49,9 +70,13 @@ export function wrapDist(a: number, b: number): number {
 }
 
 /**
- * If the ball is falling and overlaps the top of a platform this step, return
- * the bounced ball; otherwise null. `prevY` is the ball's y before the step, so
- * we only bounce when it crosses the platform surface downward (no tunneling).
+ * If the ball is falling and lands on the TOP of a shelf this step, return the
+ * bounced ball; otherwise null. `prevY` is the ball's y before the step.
+ *
+ * Top-surface-only: we require the ball to be moving downward (vy <= 0) AND to
+ * have been at or above the surface last step (prevY >= surface). A ball rising
+ * up through the shelf, or one already below it, never bounces — so there are no
+ * side or underneath bounces. The prevY check also prevents fast-fall tunneling.
  */
 export function tryBounce(ball: Ball, prevY: number, platform: Platform): Ball | null {
   if (ball.vy > 0) return null // moving up — pass through
@@ -62,19 +87,53 @@ export function tryBounce(ball: Ball, prevY: number, platform: Platform): Ball |
   return { ...ball, y: surface + BALL_RADIUS, vy: BOUNCE_VY }
 }
 
+/** Gap between shelf `index - 1` and shelf `index` (0 for index <= 0). */
+export function spacingBefore(index: number): number {
+  if (index <= 0) return 0
+  return Math.min(MAX_SPACING, BASE_SPACING + (index - 1) * SPACING_RAMP)
+}
+
+/** Cumulative world-y of a shelf index (spacing ramps then caps at MAX_SPACING). */
+export function platformY(index: number): number {
+  if (index <= 0) return 0
+  const linN = Math.min(index, RAMP_CAP_INDEX)
+  // sum_{k=1..linN} (BASE_SPACING + (k-1)*SPACING_RAMP)
+  let y = linN * BASE_SPACING + (SPACING_RAMP * (linN - 1) * linN) / 2
+  if (index > RAMP_CAP_INDEX) y += (index - RAMP_CAP_INDEX) * MAX_SPACING
+  return y
+}
+
+const Y_AT_CAP = platformY(RAMP_CAP_INDEX)
+
+/** Continuous inverse of platformY: the (fractional) index at a given y. */
+function indexAtY(y: number): number {
+  if (y <= 0) return 0
+  if (SPACING_RAMP === 0) return y / BASE_SPACING
+  if (y <= Y_AT_CAP) {
+    // Solve a*n^2 + b*n - y = 0 for n, with a = ramp/2, b = BASE - ramp/2.
+    const a = SPACING_RAMP / 2
+    const b = BASE_SPACING - SPACING_RAMP / 2
+    return (-b + Math.sqrt(b * b + 4 * a * y)) / (2 * a)
+  }
+  return RAMP_CAP_INDEX + (y - Y_AT_CAP) / MAX_SPACING
+}
+
+/** Index of the shelf nearest a y, for narrowing collision/draw checks. */
+export const nearestPlatformIndex = (y: number): number => Math.max(0, Math.round(indexAtY(y)))
+
+/** True once a shelf has been bounced on enough times to vanish. */
+export const platformBroken = (bounces: number): boolean => bounces >= MAX_BOUNCES
+
 /**
- * Deterministic platform for a given index. Platforms climb by PLATFORM_SPACING
- * and wander horizontally; higher platforms get slightly narrower.
+ * Deterministic shelf for a given index. Shelves climb by the ramping spacing
+ * and wander horizontally; higher shelves get slightly narrower.
  */
 export function platformAt(seed: number, index: number): Platform {
   const rand = mulberry32((seed + index * 2654435761) >>> 0)
   const width = Math.max(0.14, PLATFORM_WIDTH - index * 0.0009)
   return {
     x: width / 2 + rand() * (1 - width),
-    y: index * PLATFORM_SPACING,
+    y: platformY(index),
     width,
   }
 }
-
-/** Index of the platform nearest a y, for narrowing collision checks. */
-export const nearestPlatformIndex = (y: number): number => Math.round(y / PLATFORM_SPACING)

--- a/src/services/ballBounce.ts
+++ b/src/services/ballBounce.ts
@@ -1,0 +1,80 @@
+/**
+ * Ball Bounce — a doodle-jump-style climber. The ball is always falling under
+ * gravity; landing on a platform (only while moving downward) bounces it back
+ * up. You steer left/right (with screen wrap). Physics and deterministic,
+ * endless platform generation are pure and testable.
+ *
+ * Coordinates: x in [0,1] (wraps), y in climb units that only trend upward.
+ * The view scales to pixels; velocities are per second.
+ */
+
+import { mulberry32 } from './seed'
+
+export interface Ball {
+  x: number
+  y: number
+  vx: number
+  vy: number // up is positive
+}
+
+export interface Platform {
+  x: number // center, 0..1
+  y: number
+  width: number // fraction of play width
+}
+
+export const GRAVITY = 9 // climb units / s^2
+export const BOUNCE_VY = 4.6 // upward speed on a bounce
+export const MOVE_VX = 0.75 // horizontal speed from steering input
+export const BALL_RADIUS = 0.035
+export const PLATFORM_SPACING = 0.72 // vertical gap between platforms (units)
+export const PLATFORM_WIDTH = 0.26
+
+/** Advance the ball. `steer` is -1/0/1; screen wraps horizontally. */
+export function stepBall(ball: Ball, steer: -1 | 0 | 1, dtMs: number): Ball {
+  const dt = dtMs / 1000
+  const vy = ball.vy - GRAVITY * dt
+  const vx = steer * MOVE_VX
+  let x = ball.x + vx * dt
+  if (x < 0) x += 1
+  if (x >= 1) x -= 1
+  const y = ball.y + vy * dt
+  return { x, y, vx, vy }
+}
+
+/** Horizontal distance between two x's accounting for wrap (0..0.5). */
+export function wrapDist(a: number, b: number): number {
+  const d = Math.abs(a - b)
+  return Math.min(d, 1 - d)
+}
+
+/**
+ * If the ball is falling and overlaps the top of a platform this step, return
+ * the bounced ball; otherwise null. `prevY` is the ball's y before the step, so
+ * we only bounce when it crosses the platform surface downward (no tunneling).
+ */
+export function tryBounce(ball: Ball, prevY: number, platform: Platform): Ball | null {
+  if (ball.vy > 0) return null // moving up — pass through
+  const surface = platform.y
+  const crossed = prevY >= surface && ball.y <= surface + BALL_RADIUS
+  if (!crossed) return null
+  if (wrapDist(ball.x, platform.x) > platform.width / 2 + BALL_RADIUS) return null
+  return { ...ball, y: surface + BALL_RADIUS, vy: BOUNCE_VY }
+}
+
+/**
+ * Deterministic platform for a given index. Platforms climb by PLATFORM_SPACING
+ * and wander horizontally; higher platforms get slightly narrower.
+ */
+export function platformAt(seed: number, index: number): Platform {
+  const rand = mulberry32((seed + index * 2654435761) >>> 0)
+  const width = Math.max(0.14, PLATFORM_WIDTH - index * 0.0009)
+  return {
+    x: width / 2 + rand() * (1 - width),
+    y: index * PLATFORM_SPACING,
+    width,
+  }
+}
+
+/** Index of the platform nearest a y, for narrowing collision checks. */
+export const nearestPlatformIndex = (y: number): number => Math.round(y / PLATFORM_SPACING)

--- a/src/services/colorMemory.spec.ts
+++ b/src/services/colorMemory.spec.ts
@@ -25,6 +25,9 @@ describe('hslToRgb', () => {
     expect(hslToRgb(240, 1, 0.5)).toEqual({ r: 0, g: 0, b: 255 }) // blue
     expect(hslToRgb(0, 0, 0.5)).toEqual({ r: 128, g: 128, b: 128 }) // gray
   })
+  it('wraps hue at 360 back to 0 (red)', () => {
+    expect(hslToRgb(360, 1, 0.5)).toEqual({ r: 255, g: 0, b: 0 })
+  })
 })
 
 describe('randomColor', () => {

--- a/src/services/colorMemory.spec.ts
+++ b/src/services/colorMemory.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MAX_DISTANCE,
+  clampChannel,
+  hslToRgb,
+  randomColor,
+  rating,
+  redmeanDistance,
+  scorePercent,
+  type RGB,
+} from './colorMemory'
+
+describe('clampChannel', () => {
+  it('rounds and clamps to 0-255', () => {
+    expect(clampChannel(-5)).toBe(0)
+    expect(clampChannel(300)).toBe(255)
+    expect(clampChannel(127.6)).toBe(128)
+  })
+})
+
+describe('hslToRgb', () => {
+  it('maps known hues correctly', () => {
+    expect(hslToRgb(0, 1, 0.5)).toEqual({ r: 255, g: 0, b: 0 }) // red
+    expect(hslToRgb(120, 1, 0.5)).toEqual({ r: 0, g: 255, b: 0 }) // green
+    expect(hslToRgb(240, 1, 0.5)).toEqual({ r: 0, g: 0, b: 255 }) // blue
+    expect(hslToRgb(0, 0, 0.5)).toEqual({ r: 128, g: 128, b: 128 }) // gray
+  })
+})
+
+describe('randomColor', () => {
+  it('returns valid channels and is deterministic for an RNG', () => {
+    const seq = [0.1, 0.6, 0.5]
+    let i = 0
+    const rng = () => seq[i++ % seq.length]
+    const a = randomColor(rng)
+    for (const v of [a.r, a.g, a.b]) {
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThanOrEqual(255)
+    }
+    i = 0
+    expect(randomColor(rng)).toEqual(a)
+  })
+})
+
+describe('redmeanDistance', () => {
+  it('is zero for identical colors', () => {
+    expect(redmeanDistance({ r: 10, g: 20, b: 30 }, { r: 10, g: 20, b: 30 })).toBe(0)
+  })
+  it('is maximal for black vs white', () => {
+    expect(redmeanDistance({ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 })).toBeCloseTo(MAX_DISTANCE)
+  })
+})
+
+describe('scorePercent', () => {
+  const target: RGB = { r: 120, g: 60, b: 200 }
+  it('is 100 for an exact match', () => {
+    expect(scorePercent(target, { ...target })).toBe(100)
+  })
+  it('is 0 for the maximal-distance opposite', () => {
+    expect(scorePercent({ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 })).toBe(0)
+  })
+  it('rewards closer guesses with strictly higher scores', () => {
+    const near = scorePercent(target, { r: 125, g: 65, b: 195 })
+    const far = scorePercent(target, { r: 200, g: 200, b: 40 })
+    expect(near).toBeGreaterThan(far)
+    expect(near).toBeGreaterThan(0)
+    expect(near).toBeLessThanOrEqual(100)
+  })
+})
+
+describe('rating', () => {
+  it('labels score tiers', () => {
+    expect(rating(100)).toBe('Perfect!')
+    expect(rating(85)).toBe('Great')
+    expect(rating(10)).toBe('Way off')
+  })
+})

--- a/src/services/colorMemory.ts
+++ b/src/services/colorMemory.ts
@@ -24,7 +24,7 @@ export function randomColor(rng: () => number): RGB {
 
 export function hslToRgb(h: number, s: number, l: number): RGB {
   const c = (1 - Math.abs(2 * l - 1)) * s
-  const hp = h / 60
+  const hp = (((h % 360) + 360) % 360) / 60 // normalize so 360 wraps to 0 (red)
   const x = c * (1 - Math.abs((hp % 2) - 1))
   let r = 0
   let g = 0

--- a/src/services/colorMemory.ts
+++ b/src/services/colorMemory.ts
@@ -1,0 +1,81 @@
+/**
+ * Color-from-memory logic — generate a target color, then score how close the
+ * player's recreated color is. Uses the "redmean" low-cost perceptual distance
+ * so the score tracks how different two colors *look*, not just their raw RGB
+ * gap. Pure and RNG-injectable so it's testable.
+ */
+
+export interface RGB {
+  r: number
+  g: number
+  b: number
+}
+
+export const clampChannel = (v: number): number => Math.max(0, Math.min(255, Math.round(v)))
+
+/** A random, reasonably saturated color (avoids near-black/near-white targets). */
+export function randomColor(rng: () => number): RGB {
+  // Build from HSL for pleasant, distinguishable targets, then convert to RGB.
+  const h = rng() * 360
+  const s = 0.45 + rng() * 0.5 // 45–95% saturation
+  const l = 0.35 + rng() * 0.4 // 35–75% lightness
+  return hslToRgb(h, s, l)
+}
+
+export function hslToRgb(h: number, s: number, l: number): RGB {
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const hp = h / 60
+  const x = c * (1 - Math.abs((hp % 2) - 1))
+  let r = 0
+  let g = 0
+  let b = 0
+  if (hp < 1) [r, g, b] = [c, x, 0]
+  else if (hp < 2) [r, g, b] = [x, c, 0]
+  else if (hp < 3) [r, g, b] = [0, c, x]
+  else if (hp < 4) [r, g, b] = [0, x, c]
+  else if (hp < 5) [r, g, b] = [x, 0, c]
+  else [r, g, b] = [c, 0, x]
+  const m = l - c / 2
+  return {
+    r: clampChannel((r + m) * 255),
+    g: clampChannel((g + m) * 255),
+    b: clampChannel((b + m) * 255),
+  }
+}
+
+/**
+ * Redmean perceptual color distance. Weights the red/blue channels by the mean
+ * red level, approximating how the eye perceives differences.
+ */
+export function redmeanDistance(a: RGB, b: RGB): number {
+  const rbar = (a.r + b.r) / 2
+  const dr = a.r - b.r
+  const dg = a.g - b.g
+  const db = a.b - b.b
+  return Math.sqrt((2 + rbar / 256) * dr * dr + 4 * dg * dg + (2 + (255 - rbar) / 256) * db * db)
+}
+
+/** The largest possible redmean distance (black↔white), for normalizing scores. */
+export const MAX_DISTANCE = redmeanDistance({ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 })
+
+/**
+ * Score a guess against the target as a 0–100 percentage of perceptual accuracy.
+ * Squared so that only very close guesses earn top marks (a linear scale feels
+ * too generous — halfway-off should not read as 50%).
+ */
+export function scorePercent(target: RGB, guess: RGB): number {
+  const ratio = Math.min(1, redmeanDistance(target, guess) / MAX_DISTANCE)
+  return Math.round(100 * (1 - ratio) ** 2)
+}
+
+export const toCss = (c: RGB): string => `rgb(${c.r}, ${c.g}, ${c.b})`
+
+/** A qualitative label for a score, for post-round feedback. */
+export function rating(score: number): string {
+  if (score >= 98) return 'Perfect!'
+  if (score >= 90) return 'Amazing'
+  if (score >= 78) return 'Great'
+  if (score >= 60) return 'Good'
+  if (score >= 40) return 'Close-ish'
+  return 'Way off'
+}

--- a/src/services/connect4.spec.ts
+++ b/src/services/connect4.spec.ts
@@ -82,6 +82,10 @@ describe('evaluate', () => {
     const edge = play(emptyBoard(), 0, AI)
     expect(evaluate(center, AI)).toBeGreaterThan(evaluate(edge, AI))
   })
+  it('is antisymmetric between players (required for negamax)', () => {
+    const b = withMoves([[3, AI], [3, PLAYER], [2, AI], [4, PLAYER], [2, AI]])
+    expect(evaluate(b, AI)).toBe(-evaluate(b, PLAYER))
+  })
 })
 
 describe('bestMove', () => {

--- a/src/services/connect4.spec.ts
+++ b/src/services/connect4.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import {
+  AI,
+  COLS,
+  PLAYER,
+  ROWS,
+  type Board,
+  bestMove,
+  dropRow,
+  emptyBoard,
+  evaluate,
+  findWin,
+  isFull,
+  isWin,
+  play,
+  validMoves,
+} from './connect4'
+
+const rng = () => 0.42 // fixed, deterministic tie-breaks
+
+/** Drop discs down the given columns, alternating or as specified. */
+const withMoves = (cols: Array<[number, 1 | 2]>): Board => {
+  let b = emptyBoard()
+  for (const [col, who] of cols) b = play(b, col, who)
+  return b
+}
+
+describe('dropRow / play', () => {
+  it('stacks discs from the bottom up', () => {
+    let b = emptyBoard()
+    expect(dropRow(b, 3)).toBe(ROWS - 1)
+    b = play(b, 3, PLAYER)
+    expect(dropRow(b, 3)).toBe(ROWS - 2)
+    expect(b[(ROWS - 1) * COLS + 3]).toBe(PLAYER)
+  })
+  it('reports a full column as -1', () => {
+    let b = emptyBoard()
+    for (let i = 0; i < ROWS; i += 1) b = play(b, 0, PLAYER)
+    expect(dropRow(b, 0)).toBe(-1)
+    expect(validMoves(b)).not.toContain(0)
+  })
+})
+
+describe('findWin / isWin', () => {
+  it('detects a horizontal four', () => {
+    const b = withMoves([[0, PLAYER], [1, PLAYER], [2, PLAYER], [3, PLAYER]])
+    expect(isWin(b, PLAYER)).toBe(true)
+    expect(findWin(b, PLAYER)).toHaveLength(4)
+  })
+  it('detects a vertical four', () => {
+    const b = withMoves([[5, AI], [5, AI], [5, AI], [5, AI]])
+    expect(isWin(b, AI)).toBe(true)
+  })
+  it('detects a diagonal four', () => {
+    // Build a ↘/↗ staircase.
+    const b = withMoves([
+      [0, PLAYER],
+      [1, AI], [1, PLAYER],
+      [2, AI], [2, AI], [2, PLAYER],
+      [3, AI], [3, AI], [3, AI], [3, PLAYER],
+    ])
+    expect(isWin(b, PLAYER)).toBe(true)
+  })
+  it('returns null / false when there is no four', () => {
+    const b = withMoves([[0, PLAYER], [1, PLAYER], [2, PLAYER]])
+    expect(findWin(b, PLAYER)).toBeNull()
+    expect(isWin(b, PLAYER)).toBe(false)
+  })
+})
+
+describe('isFull', () => {
+  it('is true only when every cell is filled', () => {
+    expect(isFull(emptyBoard())).toBe(false)
+    const full = new Array(COLS * ROWS).fill(PLAYER) as Board
+    expect(isFull(full)).toBe(true)
+  })
+})
+
+describe('evaluate', () => {
+  it('prefers center control', () => {
+    const center = play(emptyBoard(), 3, AI)
+    const edge = play(emptyBoard(), 0, AI)
+    expect(evaluate(center, AI)).toBeGreaterThan(evaluate(edge, AI))
+  })
+})
+
+describe('bestMove', () => {
+  it('takes an immediate winning move', () => {
+    // AI has three in a row along the bottom (cols 0-2); playing col 3 wins.
+    const b = withMoves([[0, AI], [1, AI], [2, AI]])
+    expect(bestMove(b, 'hard', rng)).toBe(3)
+  })
+
+  it('blocks the opponent’s immediate win', () => {
+    // Player threatens to complete cols 0-3 on the bottom row; AI must play col 3.
+    const b = withMoves([[0, PLAYER], [1, PLAYER], [2, PLAYER]])
+    expect(bestMove(b, 'hard', rng)).toBe(3)
+  })
+
+  it('returns a legal move on an empty board', () => {
+    const move = bestMove(emptyBoard(), 'medium', rng)
+    expect(validMoves(emptyBoard())).toContain(move)
+  })
+
+  it('never returns a full column', () => {
+    let b = emptyBoard()
+    for (let i = 0; i < ROWS; i += 1) b = play(b, 3, i % 2 === 0 ? PLAYER : AI)
+    const move = bestMove(b, 'hard', rng)
+    expect(move).not.toBe(3)
+    expect(validMoves(b)).toContain(move)
+  })
+})

--- a/src/services/connect4.ts
+++ b/src/services/connect4.ts
@@ -72,33 +72,28 @@ export function findWin(board: Board, who: Disc): number[] | null {
 export const isWin = (board: Board, who: Disc): boolean => findWin(board, who) !== null
 export const isFull = (board: Board): boolean => board.every((v) => v !== EMPTY)
 
-/** Count length-4 windows and weight them — the heart of the heuristic. */
-function scoreWindow(cells: Disc[], who: Disc): number {
+/** Positive-only value of a length-4 window for `who` (0 if the window is
+ *  blocked by an opponent disc, so it can never complete). */
+function windowValue(cells: Disc[], who: Disc): number {
   const opp = who === AI ? PLAYER : AI
   let mine = 0
-  let theirs = 0
   for (const v of cells) {
+    if (v === opp) return 0 // opponent disc present → dead window for `who`
     if (v === who) mine += 1
-    else if (v === opp) theirs += 1
   }
-  if (mine > 0 && theirs > 0) return 0 // blocked window, worthless
-  if (mine === 4) return 10000
   if (mine === 3) return 50
   if (mine === 2) return 10
-  if (theirs === 3) return -80 // value blocking a bit higher than building
-  if (theirs === 2) return -10
+  if (mine === 1) return 1
   return 0
 }
 
-/** Static evaluation of a non-terminal board from `who`'s perspective. */
-export function evaluate(board: Board, who: Disc): number {
+/** Raw positional value for a single side (center control + open windows). */
+function heuristic(board: Board, who: Disc): number {
   let score = 0
-  // Center control is valuable.
   const center = Math.floor(COLS / 2)
   for (let r = 0; r < ROWS; r += 1) {
     if (board[r * COLS + center] === who) score += 6
   }
-  // All length-4 windows.
   for (let r = 0; r < ROWS; r += 1) {
     for (let c = 0; c < COLS; c += 1) {
       for (const [dr, dc] of DIRECTIONS) {
@@ -107,11 +102,21 @@ export function evaluate(board: Board, who: Disc): number {
         if (er < 0 || er >= ROWS || ec < 0 || ec >= COLS) continue
         const cells: Disc[] = []
         for (let k = 0; k < 4; k += 1) cells.push(board[(r + k * dr) * COLS + (c + k * dc)])
-        score += scoreWindow(cells, who)
+        score += windowValue(cells, who)
       }
     }
   }
   return score
+}
+
+/**
+ * Static evaluation of a non-terminal board from `who`'s perspective. Defined
+ * as own value minus opponent value so it's antisymmetric
+ * (evaluate(b, who) === -evaluate(b, opp)) — required for negamax to be sound.
+ */
+export function evaluate(board: Board, who: Disc): number {
+  const opp = who === AI ? PLAYER : AI
+  return heuristic(board, who) - heuristic(board, opp)
 }
 
 /** Move-ordering: try center columns first for better alpha-beta pruning. */

--- a/src/services/connect4.ts
+++ b/src/services/connect4.ts
@@ -1,0 +1,184 @@
+/**
+ * Connect 4 engine — board rules plus a negamax (minimax) AI with alpha-beta
+ * pruning. Pure and deterministic (AI tie-breaks use a passed-in RNG), so the
+ * bot is unit testable.
+ *
+ * Board: 7 columns × 6 rows, stored row-major from the TOP (index = row*COLS +
+ * col, row 0 is the top). 0 = empty, 1 = player, 2 = AI.
+ */
+
+export const COLS = 7
+export const ROWS = 6
+export const EMPTY = 0
+export const PLAYER = 1
+export const AI = 2
+
+export type Disc = 0 | 1 | 2
+export type Board = Disc[]
+
+export const emptyBoard = (): Board => new Array(COLS * ROWS).fill(EMPTY) as Board
+
+/** Lowest empty row in a column, or -1 if the column is full. */
+export function dropRow(board: Board, col: number): number {
+  for (let r = ROWS - 1; r >= 0; r -= 1) {
+    if (board[r * COLS + col] === EMPTY) return r
+  }
+  return -1
+}
+
+export const validMoves = (board: Board): number[] => {
+  const cols: number[] = []
+  for (let c = 0; c < COLS; c += 1) if (dropRow(board, c) !== -1) cols.push(c)
+  return cols
+}
+
+/** Drop a disc for `who` into `col`, returning a new board (no-op copy if full). */
+export function play(board: Board, col: number, who: Disc): Board {
+  const r = dropRow(board, col)
+  if (r === -1) return board.slice() as Board
+  const next = board.slice() as Board
+  next[r * COLS + col] = who
+  return next
+}
+
+const DIRECTIONS: Array<[number, number]> = [
+  [0, 1], // horizontal
+  [1, 0], // vertical
+  [1, 1], // diagonal ↘
+  [1, -1], // diagonal ↙
+]
+
+/** The four-in-a-row winning cells for `who`, or null if none. */
+export function findWin(board: Board, who: Disc): number[] | null {
+  for (let r = 0; r < ROWS; r += 1) {
+    for (let c = 0; c < COLS; c += 1) {
+      if (board[r * COLS + c] !== who) continue
+      for (const [dr, dc] of DIRECTIONS) {
+        const cells = [r * COLS + c]
+        let rr = r + dr
+        let cc = c + dc
+        while (rr >= 0 && rr < ROWS && cc >= 0 && cc < COLS && board[rr * COLS + cc] === who) {
+          cells.push(rr * COLS + cc)
+          if (cells.length === 4) return cells
+          rr += dr
+          cc += dc
+        }
+      }
+    }
+  }
+  return null
+}
+
+export const isWin = (board: Board, who: Disc): boolean => findWin(board, who) !== null
+export const isFull = (board: Board): boolean => board.every((v) => v !== EMPTY)
+
+/** Count length-4 windows and weight them — the heart of the heuristic. */
+function scoreWindow(cells: Disc[], who: Disc): number {
+  const opp = who === AI ? PLAYER : AI
+  let mine = 0
+  let theirs = 0
+  for (const v of cells) {
+    if (v === who) mine += 1
+    else if (v === opp) theirs += 1
+  }
+  if (mine > 0 && theirs > 0) return 0 // blocked window, worthless
+  if (mine === 4) return 10000
+  if (mine === 3) return 50
+  if (mine === 2) return 10
+  if (theirs === 3) return -80 // value blocking a bit higher than building
+  if (theirs === 2) return -10
+  return 0
+}
+
+/** Static evaluation of a non-terminal board from `who`'s perspective. */
+export function evaluate(board: Board, who: Disc): number {
+  let score = 0
+  // Center control is valuable.
+  const center = Math.floor(COLS / 2)
+  for (let r = 0; r < ROWS; r += 1) {
+    if (board[r * COLS + center] === who) score += 6
+  }
+  // All length-4 windows.
+  for (let r = 0; r < ROWS; r += 1) {
+    for (let c = 0; c < COLS; c += 1) {
+      for (const [dr, dc] of DIRECTIONS) {
+        const er = r + 3 * dr
+        const ec = c + 3 * dc
+        if (er < 0 || er >= ROWS || ec < 0 || ec >= COLS) continue
+        const cells: Disc[] = []
+        for (let k = 0; k < 4; k += 1) cells.push(board[(r + k * dr) * COLS + (c + k * dc)])
+        score += scoreWindow(cells, who)
+      }
+    }
+  }
+  return score
+}
+
+/** Move-ordering: try center columns first for better alpha-beta pruning. */
+const orderedMoves = (board: Board): number[] => {
+  const center = (COLS - 1) / 2
+  return validMoves(board).sort((a, b) => Math.abs(a - center) - Math.abs(b - center))
+}
+
+interface Search {
+  score: number
+  col: number
+}
+
+/**
+ * Negamax with alpha-beta pruning. Returns the best score (from `who`'s view)
+ * and the column to play. Terminal wins are scored with depth so the AI prefers
+ * faster wins and slower losses.
+ */
+function negamax(
+  board: Board,
+  depth: number,
+  alpha: number,
+  beta: number,
+  who: Disc,
+  rng: () => number,
+): Search {
+  const opp = who === AI ? PLAYER : AI
+  if (isWin(board, opp)) return { score: -100000 - depth, col: -1 } // opp just won
+  const moves = orderedMoves(board)
+  if (moves.length === 0) return { score: 0, col: -1 } // draw
+  if (depth === 0) return { score: evaluate(board, who), col: -1 }
+
+  let bestScore = -Infinity
+  let bestCol = moves[0]
+  let a = alpha
+  for (const col of moves) {
+    const child = play(board, col, who)
+    let score: number
+    if (isWin(child, who)) {
+      score = 100000 + depth // immediate win — best possible, prefer sooner
+    } else {
+      score = -negamax(child, depth - 1, -beta, -a, opp, rng).score
+    }
+    if (score > bestScore || (score === bestScore && rng() < 0.5)) {
+      bestScore = score
+      bestCol = col
+    }
+    if (bestScore > a) a = bestScore
+    if (a >= beta) break // prune
+  }
+  return { score: bestScore, col: bestCol }
+}
+
+export type Level = 'easy' | 'medium' | 'hard'
+const DEPTH: Record<Level, number> = { easy: 2, medium: 4, hard: 6 }
+
+/**
+ * Choose the AI's column. On easy, occasionally plays a random legal move so it
+ * feels beatable; otherwise it searches to the level's depth. Always takes an
+ * immediate win and blocks an immediate loss (via the search).
+ */
+export function bestMove(board: Board, level: Level, rng: () => number): number {
+  const moves = validMoves(board)
+  if (moves.length === 0) return -1
+  if (level === 'easy' && rng() < 0.25) {
+    return moves[Math.floor(rng() * moves.length)]
+  }
+  const { col } = negamax(board, DEPTH[level], -Infinity, Infinity, AI, rng)
+  return col === -1 ? moves[0] : col
+}

--- a/src/services/countBlocks.spec.ts
+++ b/src/services/countBlocks.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SHAPES,
+  SHAPE_CELLS,
+  asksTarget,
+  colorOf,
+  correctAnswer,
+  countForLevel,
+  countOf,
+  makeRound,
+} from './countBlocks'
+
+describe('countForLevel', () => {
+  it('grows with level and caps', () => {
+    expect(countForLevel(1)).toBe(5)
+    expect(countForLevel(2)).toBe(7)
+    expect(countForLevel(100)).toBe(24)
+  })
+})
+
+describe('asksTarget', () => {
+  it('switches to the targeted question at level 3', () => {
+    expect(asksTarget(1)).toBe(false)
+    expect(asksTarget(2)).toBe(false)
+    expect(asksTarget(3)).toBe(true)
+  })
+})
+
+describe('makeRound', () => {
+  it('is deterministic for level + seed', () => {
+    expect(makeRound(4, 'abc')).toEqual(makeRound(4, 'abc'))
+  })
+  it('produces the level count of pieces, each in-bounds', () => {
+    const r = makeRound(5, 'seed')
+    expect(r.pieces).toHaveLength(countForLevel(5))
+    for (const p of r.pieces) {
+      expect(SHAPES).toContain(p.shape)
+      expect(p.lane).toBeGreaterThanOrEqual(0)
+      expect(p.lane).toBeLessThan(r.lanes)
+      expect(p.startOffset).toBeGreaterThanOrEqual(0)
+      expect(p.startOffset).toBeLessThan(1)
+    }
+  })
+  it('speeds up and shortens exposure as levels rise', () => {
+    const a = makeRound(1, 's')
+    const b = makeRound(6, 's')
+    expect(b.speed).toBeGreaterThan(a.speed)
+    expect(b.exposureMs).toBeLessThan(a.exposureMs)
+    expect(b.exposureMs).toBeGreaterThanOrEqual(2200)
+  })
+})
+
+describe('countOf / correctAnswer', () => {
+  it('countOf tallies pieces of a shape', () => {
+    const r = makeRound(4, 'seed')
+    const total = SHAPES.reduce((sum, s) => sum + countOf(r, s), 0)
+    expect(total).toBe(r.pieces.length)
+  })
+  it('correctAnswer is total below level 3', () => {
+    const r = makeRound(2, 'seed')
+    expect(correctAnswer(r)).toBe(r.pieces.length)
+  })
+  it('correctAnswer is the target count at level 3+', () => {
+    const r = makeRound(4, 'seed')
+    expect(correctAnswer(r)).toBe(countOf(r, r.target))
+  })
+})
+
+describe('shape data', () => {
+  it('every shape has four cells and a color', () => {
+    for (const s of SHAPES) {
+      expect(SHAPE_CELLS[s]).toHaveLength(4)
+      expect(colorOf(s)).toMatch(/^#/)
+    }
+  })
+})

--- a/src/services/countBlocks.spec.ts
+++ b/src/services/countBlocks.spec.ts
@@ -41,6 +41,20 @@ describe('makeRound', () => {
       expect(p.startOffset).toBeLessThan(1)
     }
   })
+  it('separates pieces sharing a lane so they cannot visually merge', () => {
+    const r = makeRound(8, 'lanes') // high level → many pieces, more lane sharing
+    for (let lane = 0; lane < r.lanes; lane += 1) {
+      const offsets = r.pieces
+        .filter((p) => p.lane === lane)
+        .map((p) => p.startOffset)
+        .sort((a, b) => a - b)
+      const m = offsets.length
+      for (let i = 1; i < m; i += 1) {
+        // Slots are 1/m apart with <=0.2/m jitter each side → gap >= 0.6/m.
+        expect(offsets[i] - offsets[i - 1]).toBeGreaterThan(0.5 / m)
+      }
+    }
+  })
   it('speeds up and shortens exposure as levels rise', () => {
     const a = makeRound(1, 's')
     const b = makeRound(6, 's')

--- a/src/services/countBlocks.ts
+++ b/src/services/countBlocks.ts
@@ -1,0 +1,106 @@
+/**
+ * Count the Blocks — a memory game. A set of tetromino-like shapes slides across
+ * the screen; afterward you answer how many there were (and, later, how many of
+ * a target shape). Rounds get harder: more shapes, faster, shorter exposure.
+ * Generation and difficulty are pure and testable.
+ */
+
+import { mulberry32 } from './seed'
+
+export const SHAPES = ['I', 'O', 'T', 'S', 'Z', 'L', 'J'] as const
+export type Shape = (typeof SHAPES)[number]
+
+export interface Piece {
+  shape: Shape
+  lane: number // vertical lane index (row it travels along)
+  color: string
+  /** Fraction along its travel where it starts, so pieces are staggered. */
+  startOffset: number
+}
+
+export interface Round {
+  level: number
+  pieces: Piece[]
+  target: Shape // "how many <target>?" is asked from level 3 on
+  speed: number // lanes-per-second-ish scroll factor (view scales it)
+  exposureMs: number // how long the shapes stream past
+  lanes: number
+}
+
+const COLORS: Record<Shape, string> = {
+  I: '#22d3ee',
+  O: '#facc15',
+  T: '#a855f7',
+  S: '#22c55e',
+  Z: '#ef4444',
+  L: '#f97316',
+  J: '#3b82f6',
+}
+
+export const colorOf = (shape: Shape): string => COLORS[shape]
+
+/** How many shapes appear at a given level. */
+export function countForLevel(level: number): number {
+  return Math.min(24, 3 + level * 2)
+}
+
+/** Whether this level asks the harder "how many of shape X" question. */
+export function asksTarget(level: number): boolean {
+  return level >= 3
+}
+
+/** Build a deterministic round for a level from a seed. */
+export function makeRound(level: number, seed: string): Round {
+  const rng = mulberry32((hash(seed) + level * 2654435761) >>> 0)
+  const count = countForLevel(level)
+  const lanes = Math.min(8, 4 + Math.floor(level / 2))
+  const pieces: Piece[] = []
+  for (let i = 0; i < count; i += 1) {
+    const shape = SHAPES[Math.floor(rng() * SHAPES.length)]
+    pieces.push({
+      shape,
+      lane: Math.floor(rng() * lanes),
+      color: colorOf(shape),
+      startOffset: rng(),
+    })
+  }
+  const target = SHAPES[Math.floor(rng() * SHAPES.length)]
+  return {
+    level,
+    pieces,
+    target,
+    speed: 0.5 + level * 0.12,
+    exposureMs: Math.max(2200, 5200 - level * 260),
+    lanes,
+  }
+}
+
+/** Count pieces matching a shape (answer key for the target question). */
+export function countOf(round: Round, shape: Shape): number {
+  return round.pieces.filter((p) => p.shape === shape).length
+}
+
+/** The correct answer for a round given whether it's the targeted variant. */
+export function correctAnswer(round: Round): number {
+  return asksTarget(round.level) ? countOf(round, round.target) : round.pieces.length
+}
+
+/** Cell layout (unit squares) for drawing each shape, normalized to origin. */
+export const SHAPE_CELLS: Record<Shape, Array<[number, number]>> = {
+  I: [[0, 0], [1, 0], [2, 0], [3, 0]],
+  O: [[0, 0], [1, 0], [0, 1], [1, 1]],
+  T: [[0, 0], [1, 0], [2, 0], [1, 1]],
+  S: [[1, 0], [2, 0], [0, 1], [1, 1]],
+  Z: [[0, 0], [1, 0], [1, 1], [2, 1]],
+  L: [[0, 0], [0, 1], [1, 1], [2, 1]],
+  J: [[2, 0], [0, 1], [1, 1], [2, 1]],
+}
+
+function hash(str: string): number {
+  let h = 2166136261
+  for (let i = 0; i < str.length; i += 1) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}

--- a/src/services/countBlocks.ts
+++ b/src/services/countBlocks.ts
@@ -57,11 +57,16 @@ export function makeRound(level: number, seed: string): Round {
   const pieces: Piece[] = []
   for (let i = 0; i < count; i += 1) {
     const shape = SHAPES[Math.floor(rng() * SHAPES.length)]
-    pieces.push({
-      shape,
-      lane: Math.floor(rng() * lanes),
-      color: colorOf(shape),
-      startOffset: rng(),
+    pieces.push({ shape, lane: Math.floor(rng() * lanes), color: colorOf(shape), startOffset: 0 })
+  }
+  // Spread pieces that share a lane into separated time slots so they never
+  // overlap on screen and get miscounted.
+  const byLane: Piece[][] = Array.from({ length: lanes }, () => [])
+  for (const p of pieces) byLane[p.lane].push(p)
+  for (const lanePieces of byLane) {
+    const m = lanePieces.length
+    lanePieces.forEach((p, k) => {
+      p.startOffset = (k + 0.5) / m + (rng() - 0.5) * (0.4 / m) // centered in its slot, small jitter
     })
   }
   const target = SHAPES[Math.floor(rng() * SHAPES.length)]

--- a/src/services/game2048.spec.ts
+++ b/src/services/game2048.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { move, spawn, canMove, hasWon, emptyCells, SIZE, type Tile } from './game2048'
+
+/** Build tiles from a 2D value grid (0 = empty). IDs are row-major cell indices. */
+const fromGrid = (rows: number[][]): Tile[] => {
+  const tiles: Tile[] = []
+  rows.forEach((row, r) =>
+    row.forEach((value, c) => {
+      if (value) tiles.push({ id: r * SIZE + c, value, row: r, col: c })
+    }),
+  )
+  return tiles
+}
+
+/** Render tiles back to a 2D value grid for easy assertions. */
+const toGrid = (tiles: Tile[]): number[][] => {
+  const g = Array.from({ length: SIZE }, () => Array<number>(SIZE).fill(0))
+  for (const t of tiles) g[t.row][t.col] = t.value
+  return g
+}
+
+describe('move', () => {
+  it('slides tiles to the wall without merging distinct values', () => {
+    const { tiles, moved, gained } = move(fromGrid([
+      [2, 0, 0, 4],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]), 'left')
+    expect(toGrid(tiles)[0]).toEqual([2, 4, 0, 0])
+    expect(moved).toBe(true)
+    expect(gained).toBe(0)
+  })
+
+  it('merges equal adjacent tiles and scores the sum', () => {
+    const { tiles, gained, consumed } = move(fromGrid([
+      [2, 2, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]), 'left')
+    expect(toGrid(tiles)[0]).toEqual([4, 0, 0, 0])
+    expect(gained).toBe(4)
+    expect(consumed).toHaveLength(1)
+  })
+
+  it('merges only once per tile per move (2 2 2 2 → 4 4)', () => {
+    const { tiles, gained } = move(fromGrid([
+      [2, 2, 2, 2],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]), 'left')
+    expect(toGrid(tiles)[0]).toEqual([4, 4, 0, 0])
+    expect(gained).toBe(8)
+  })
+
+  it('merges toward the direction of travel (4 2 2 → left → 4 4)', () => {
+    const { tiles } = move(fromGrid([
+      [4, 2, 2, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]), 'left')
+    expect(toGrid(tiles)[0]).toEqual([4, 4, 0, 0])
+  })
+
+  it('reports no move when nothing can shift', () => {
+    const { moved } = move(fromGrid([
+      [2, 4, 2, 4],
+      [4, 2, 4, 2],
+      [2, 4, 2, 4],
+      [4, 2, 4, 2],
+    ]), 'left')
+    expect(moved).toBe(false)
+  })
+
+  it('does not mutate the input tiles', () => {
+    const input = fromGrid([[2, 2, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])
+    const snapshot = input.map((t) => ({ ...t }))
+    move(input, 'left')
+    expect(input).toEqual(snapshot)
+  })
+
+  it('slides down correctly', () => {
+    const { tiles } = move(fromGrid([
+      [2, 0, 0, 0],
+      [2, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]), 'down')
+    expect(toGrid(tiles)[3][0]).toBe(4)
+  })
+})
+
+describe('spawn', () => {
+  it('fills an empty cell with a 2 or 4', () => {
+    const tiles = fromGrid([[2, 2, 2, 2], [2, 2, 2, 2], [2, 2, 2, 0], [2, 2, 2, 2]])
+    const t = spawn(tiles, () => 0.5, 99)
+    expect(t).not.toBeNull()
+    expect(t!.row).toBe(2)
+    expect(t!.col).toBe(3)
+    expect([2, 4]).toContain(t!.value)
+  })
+
+  it('returns null on a full board', () => {
+    const full = fromGrid(Array.from({ length: 4 }, () => [2, 2, 2, 2]))
+    expect(spawn(full, () => 0, 1)).toBeNull()
+  })
+
+  it('spawns a 4 only when the value roll is >= 0.9', () => {
+    const board = fromGrid([[0, 0, 0, 0], [2, 2, 2, 2], [2, 2, 2, 2], [2, 2, 2, 2]])
+    expect(spawn(board, () => 0.95, 1)!.value).toBe(4)
+    expect(spawn(board, () => 0.1, 1)!.value).toBe(2)
+  })
+})
+
+describe('canMove', () => {
+  it('is true with empty cells', () => {
+    expect(canMove(fromGrid([[2, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]))).toBe(true)
+  })
+  it('is true on a full board with an available merge', () => {
+    expect(canMove(fromGrid([[2, 2, 4, 8], [4, 8, 16, 32], [2, 4, 8, 16], [4, 8, 16, 32]]))).toBe(true)
+  })
+  it('is false on a full board with no merges (game over)', () => {
+    expect(canMove(fromGrid([[2, 4, 2, 4], [4, 2, 4, 2], [2, 4, 2, 4], [4, 2, 4, 2]]))).toBe(false)
+  })
+})
+
+describe('hasWon', () => {
+  it('detects reaching 2048', () => {
+    expect(hasWon(fromGrid([[2048, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]))).toBe(true)
+    expect(hasWon(fromGrid([[1024, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]))).toBe(false)
+  })
+})
+
+describe('emptyCells', () => {
+  it('counts and orders empty cells row-major', () => {
+    const cells = emptyCells(fromGrid([[2, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 2]]))
+    expect(cells).toHaveLength(14)
+    expect(cells[0]).toEqual({ row: 0, col: 1 })
+  })
+})

--- a/src/services/game2048.ts
+++ b/src/services/game2048.ts
@@ -1,0 +1,143 @@
+/**
+ * 2048 core logic — pure, deterministic, and framework-free so it can be unit
+ * tested and driven by a seeded RNG. The view owns tile identity/animation; this
+ * module only moves values around a grid.
+ */
+
+export const SIZE = 4
+export const WIN_VALUE = 2048
+
+export type Direction = 'left' | 'right' | 'up' | 'down'
+
+export interface Tile {
+  id: number
+  value: number
+  row: number
+  col: number
+  /** Freshly spawned this turn (drives the pop-in animation). */
+  isNew?: boolean
+  /** Result of a merge this turn (drives the merge pop animation). */
+  merged?: boolean
+}
+
+export interface MoveResult {
+  /** The board after the move: survivors, with merged tiles carrying the new value. */
+  tiles: Tile[]
+  /** Tiles that merged away, positioned at their merge target so they can slide in. */
+  consumed: Tile[]
+  /** Points scored this move (sum of every merged tile's new value). */
+  gained: number
+  /** Whether anything actually moved or merged (an unchanged board is a no-op). */
+  moved: boolean
+}
+
+const VECTORS: Record<Direction, { dr: number; dc: number }> = {
+  up: { dr: -1, dc: 0 },
+  down: { dr: 1, dc: 0 },
+  left: { dr: 0, dc: -1 },
+  right: { dr: 0, dc: 1 },
+}
+
+const inBounds = (r: number, c: number): boolean => r >= 0 && r < SIZE && c >= 0 && c < SIZE
+
+const buildGrid = (tiles: Tile[]): (Tile | null)[][] => {
+  const grid: (Tile | null)[][] = Array.from({ length: SIZE }, () => Array<Tile | null>(SIZE).fill(null))
+  for (const t of tiles) grid[t.row][t.col] = t
+  return grid
+}
+
+/**
+ * Slide/merge all tiles one step in `dir`. Pure: input tiles are never mutated —
+ * the result carries fresh tile objects (same `id`s) so the view can keep DOM
+ * nodes stable and let CSS transitions animate the movement.
+ */
+export function move(tiles: Tile[], dir: Direction): MoveResult {
+  const grid = buildGrid(tiles.map((t) => ({ ...t, isNew: false, merged: false })))
+  const { dr, dc } = VECTORS[dir]
+  // Process tiles nearest the target wall first so they settle before the rest.
+  const rowOrder = dr > 0 ? [3, 2, 1, 0] : [0, 1, 2, 3]
+  const colOrder = dc > 0 ? [3, 2, 1, 0] : [0, 1, 2, 3]
+
+  let moved = false
+  let gained = 0
+  const consumed: Tile[] = []
+
+  for (const r of rowOrder) {
+    for (const c of colOrder) {
+      const tile = grid[r][c]
+      if (!tile) continue
+
+      // Slide to the farthest empty cell in this direction.
+      let nr = r
+      let nc = c
+      while (inBounds(nr + dr, nc + dc) && !grid[nr + dr][nc + dc]) {
+        nr += dr
+        nc += dc
+      }
+
+      // A same-valued tile just beyond that (not already merged this turn) merges.
+      const tr = nr + dr
+      const tc = nc + dc
+      const target = inBounds(tr, tc) ? grid[tr][tc] : null
+      if (target && target.value === tile.value && !target.merged) {
+        grid[r][c] = null
+        target.value *= 2
+        target.merged = true
+        gained += target.value
+        consumed.push({ ...tile, row: target.row, col: target.col })
+        moved = true
+      } else if (nr !== r || nc !== c) {
+        grid[r][c] = null
+        grid[nr][nc] = tile
+        tile.row = nr
+        tile.col = nc
+        moved = true
+      }
+    }
+  }
+
+  const survivors: Tile[] = []
+  for (const rowCells of grid) for (const t of rowCells) if (t) survivors.push(t)
+  return { tiles: survivors, consumed, gained, moved }
+}
+
+/** Cells with no tile, in row-major order. */
+export function emptyCells(tiles: Tile[]): Array<{ row: number; col: number }> {
+  const occupied = new Set(tiles.map((t) => t.row * SIZE + t.col))
+  const cells: Array<{ row: number; col: number }> = []
+  for (let i = 0; i < SIZE * SIZE; i += 1) {
+    if (!occupied.has(i)) cells.push({ row: Math.floor(i / SIZE), col: i % SIZE })
+  }
+  return cells
+}
+
+/**
+ * Spawn one tile in a random empty cell — a 2 (90%) or a 4 (10%), classic odds.
+ * Returns null when the board is full. `rng` is consumed twice (cell, value).
+ */
+export function spawn(tiles: Tile[], rng: () => number, id: number): Tile | null {
+  const cells = emptyCells(tiles)
+  if (cells.length === 0) return null
+  const cell = cells[Math.floor(rng() * cells.length)]
+  const value = rng() < 0.9 ? 2 : 4
+  return { id, value, row: cell.row, col: cell.col, isNew: true }
+}
+
+/** True while any legal move (a slide or a merge) remains. */
+export function canMove(tiles: Tile[]): boolean {
+  if (tiles.length < SIZE * SIZE) return true
+  const grid = buildGrid(tiles)
+  for (let r = 0; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      const v = grid[r][c]!.value
+      if (c + 1 < SIZE && grid[r][c + 1]!.value === v) return true
+      if (r + 1 < SIZE && grid[r + 1][c]!.value === v) return true
+    }
+  }
+  return false
+}
+
+/** True once any tile reaches the win value (the player may keep going after). */
+export function hasWon(tiles: Tile[]): boolean {
+  return tiles.some((t) => t.value >= WIN_VALUE)
+}

--- a/src/services/memory.spec.ts
+++ b/src/services/memory.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SIMON_PADS,
+  buildDeck,
+  checkSimon,
+  extendSequence,
+  isMatch,
+  matchStars,
+} from './memory'
+
+describe('buildDeck', () => {
+  it('contains exactly two of each value', () => {
+    const deck = buildDeck(6, () => 0.5)
+    expect(deck).toHaveLength(12)
+    for (let v = 0; v < 6; v += 1) {
+      expect(deck.filter((x) => x === v)).toHaveLength(2)
+    }
+  })
+  it('is deterministic for a given RNG', () => {
+    let s = 1
+    const rng = () => {
+      s = (s * 1103515245 + 12345) % 2147483648
+      return s / 2147483648
+    }
+    const a = buildDeck(8, rng)
+    s = 1
+    const b = buildDeck(8, rng)
+    expect(a).toEqual(b)
+  })
+})
+
+describe('isMatch', () => {
+  it('matches equal values at different indices', () => {
+    const deck = [3, 1, 3, 2]
+    expect(isMatch(deck, 0, 2)).toBe(true)
+    expect(isMatch(deck, 0, 1)).toBe(false)
+  })
+  it('rejects the same index (double tap)', () => {
+    expect(isMatch([5, 5], 0, 0)).toBe(false)
+  })
+})
+
+describe('matchStars', () => {
+  it('awards 3 stars for a near-perfect game', () => {
+    expect(matchStars(8, 8)).toBe(3)
+    expect(matchStars(8, 10)).toBe(3)
+  })
+  it('drops to 2 then 1 star as moves grow', () => {
+    expect(matchStars(8, 15)).toBe(2)
+    expect(matchStars(8, 30)).toBe(1)
+  })
+})
+
+describe('extendSequence', () => {
+  it('adds one pad in range', () => {
+    const next = extendSequence([0, 1], () => 0.99)
+    expect(next).toHaveLength(3)
+    expect(next[2]).toBeGreaterThanOrEqual(0)
+    expect(next[2]).toBeLessThan(SIMON_PADS)
+  })
+  it('does not mutate the input', () => {
+    const seq = [2, 3]
+    extendSequence(seq, () => 0)
+    expect(seq).toEqual([2, 3])
+  })
+})
+
+describe('checkSimon', () => {
+  const seq = [0, 2, 3, 1]
+  it('reports ok for a correct prefix', () => {
+    expect(checkSimon(seq, [0, 2])).toBe('ok')
+  })
+  it('reports complete when the full sequence is matched', () => {
+    expect(checkSimon(seq, [0, 2, 3, 1])).toBe('complete')
+  })
+  it('reports wrong on a mismatch', () => {
+    expect(checkSimon(seq, [0, 1])).toBe('wrong')
+    expect(checkSimon(seq, [3])).toBe('wrong')
+  })
+})

--- a/src/services/memory.spec.ts
+++ b/src/services/memory.spec.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from 'vitest'
 import {
+  DIFFICULTIES,
+  DIFFICULTY_ORDER,
+  MAX_SIMON_PADS,
   SIMON_PADS,
   buildDeck,
   checkSimon,
   extendSequence,
   isMatch,
   matchStars,
+  padsFor,
+  pairsFor,
 } from './memory'
 
 describe('buildDeck', () => {
@@ -51,12 +56,47 @@ describe('matchStars', () => {
   })
 })
 
+describe('difficulty sizes', () => {
+  it('each preset produces the right number of cards and pads', () => {
+    for (const d of DIFFICULTY_ORDER) {
+      const { pairs, pads } = DIFFICULTIES[d]
+      expect(pairsFor(d)).toBe(pairs)
+      expect(padsFor(d)).toBe(pads)
+      // A chosen size yields a deck of exactly `pairs * 2` cards.
+      expect(buildDeck(pairsFor(d), () => 0.5)).toHaveLength(pairs * 2)
+    }
+  })
+  it('gets harder (more pairs/pads) across the ordered presets', () => {
+    const pairsSeq = DIFFICULTY_ORDER.map(pairsFor)
+    const padsSeq = DIFFICULTY_ORDER.map(padsFor)
+    expect(pairsSeq).toEqual([...pairsSeq].sort((a, b) => a - b))
+    expect(padsSeq).toEqual([...padsSeq].sort((a, b) => a - b))
+    expect(pairsSeq[pairsSeq.length - 1]).toBeGreaterThan(pairsSeq[0])
+  })
+  it('MAX_SIMON_PADS covers the largest preset', () => {
+    expect(MAX_SIMON_PADS).toBe(Math.max(...DIFFICULTY_ORDER.map(padsFor)))
+  })
+})
+
 describe('extendSequence', () => {
   it('adds one pad in range', () => {
     const next = extendSequence([0, 1], () => 0.99)
     expect(next).toHaveLength(3)
     expect(next[2]).toBeGreaterThanOrEqual(0)
     expect(next[2]).toBeLessThan(SIMON_PADS)
+  })
+  it('defaults to the classic 4 pads', () => {
+    expect(extendSequence([], () => 0.99)[0]).toBe(3)
+  })
+  it('honors a custom pad count so harder sizes use more pads', () => {
+    // rng near 1 selects the top pad index (pads - 1).
+    expect(extendSequence([], () => 0.99, 6)[0]).toBe(5)
+    // Every draw stays within [0, pads).
+    for (let r = 0; r < 1; r += 0.05) {
+      const v = extendSequence([], () => r, 6)[0]
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThan(6)
+    }
   })
   it('does not mutate the input', () => {
     const seq = [2, 3]

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -1,0 +1,52 @@
+/**
+ * Memory games logic — two modes share this module:
+ *  - "match": a concentration board of face-down pairs to flip and match.
+ *  - "simon": a growing color sequence to watch and repeat.
+ * Pure and RNG-injectable so both are testable and (for match) shareable.
+ */
+
+/** Build a shuffled deck of `pairs` matching pairs (values 0..pairs-1, twice). */
+export function buildDeck(pairs: number, rng: () => number): number[] {
+  const deck: number[] = []
+  for (let v = 0; v < pairs; v += 1) deck.push(v, v)
+  for (let i = deck.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[deck[i], deck[j]] = [deck[j], deck[i]]
+  }
+  return deck
+}
+
+/**
+ * Given the two indices a player flipped in a match game, whether they match.
+ * (Trivial, but centralizes the rule and guards against same-index double taps.)
+ */
+export function isMatch(deck: number[], a: number, b: number): boolean {
+  return a !== b && deck[a] === deck[b]
+}
+
+/** Star rating (1-3) for finishing a match board in `moves` flips-of-pairs. */
+export function matchStars(pairs: number, moves: number): number {
+  // A perfect game takes `pairs` moves. Allow some slack per tier.
+  if (moves <= pairs + Math.ceil(pairs * 0.34)) return 3
+  if (moves <= pairs + Math.ceil(pairs * 1.0)) return 2
+  return 1
+}
+
+export const SIMON_PADS = 4
+
+/** Append one random pad (0..SIMON_PADS-1) to a Simon sequence. */
+export function extendSequence(sequence: number[], rng: () => number): number[] {
+  return [...sequence, Math.floor(rng() * SIMON_PADS)]
+}
+
+/**
+ * Check a player's in-progress Simon input against the target sequence.
+ * Returns 'ok' (correct so far, more to go), 'complete' (matched the whole
+ * round), or 'wrong' (a mistake).
+ */
+export function checkSimon(sequence: number[], input: number[]): 'ok' | 'complete' | 'wrong' {
+  for (let i = 0; i < input.length; i += 1) {
+    if (input[i] !== sequence[i]) return 'wrong'
+  }
+  return input.length === sequence.length ? 'complete' : 'ok'
+}

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -34,9 +34,51 @@ export function matchStars(pairs: number, moves: number): number {
 
 export const SIMON_PADS = 4
 
-/** Append one random pad (0..SIMON_PADS-1) to a Simon sequence. */
-export function extendSequence(sequence: number[], rng: () => number): number[] {
-  return [...sequence, Math.floor(rng() * SIMON_PADS)]
+/**
+ * Difficulty presets. Each picks how many Match pairs the board has and how
+ * many Simon pads light up; the view lets the player switch between them and
+ * starts a fresh game at the chosen size.
+ */
+export type Difficulty = 'easy' | 'medium' | 'hard'
+
+export interface MemorySize {
+  /** Number of matching pairs in the Match board (deck is twice this). */
+  pairs: number
+  /** Number of Simon pads (sequence values are drawn from 0..pads-1). */
+  pads: number
+}
+
+export const DIFFICULTIES: Record<Difficulty, MemorySize> = {
+  easy: { pairs: 6, pads: 4 },
+  medium: { pairs: 8, pads: 4 },
+  hard: { pairs: 10, pads: 6 },
+}
+
+export const DIFFICULTY_ORDER: Difficulty[] = ['easy', 'medium', 'hard']
+
+/** Largest pad count any difficulty uses — the view needs a color/tone for each. */
+export const MAX_SIMON_PADS = Math.max(...DIFFICULTY_ORDER.map((d) => DIFFICULTIES[d].pads))
+
+/** Number of Simon pads for a difficulty. */
+export function padsFor(difficulty: Difficulty): number {
+  return DIFFICULTIES[difficulty].pads
+}
+
+/** Number of Match pairs for a difficulty. */
+export function pairsFor(difficulty: Difficulty): number {
+  return DIFFICULTIES[difficulty].pairs
+}
+
+/**
+ * Append one random pad to a Simon sequence. Pads defaults to the classic 4,
+ * but a harder difficulty passes a larger count so more pads come into play.
+ */
+export function extendSequence(
+  sequence: number[],
+  rng: () => number,
+  pads: number = SIMON_PADS,
+): number[] {
+  return [...sequence, Math.floor(rng() * pads)]
 }
 
 /**

--- a/src/services/memoryAudio.spec.ts
+++ b/src/services/memoryAudio.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { PAD_FREQUENCIES, SimonAudio } from './memoryAudio'
+
+// jsdom provides no AudioContext, so this exercises the guarded no-op path
+// (the same path SSR would hit) and confirms nothing throws.
+
+describe('PAD_FREQUENCIES', () => {
+  it('provides a distinct tone for every possible pad', () => {
+    expect(PAD_FREQUENCIES.length).toBeGreaterThanOrEqual(6)
+    expect(new Set(PAD_FREQUENCIES).size).toBe(PAD_FREQUENCIES.length)
+  })
+})
+
+describe('SimonAudio without AudioContext', () => {
+  afterEach(() => {
+    // ensure the global is clean between tests
+    delete (globalThis as { AudioContext?: unknown }).AudioContext
+  })
+
+  it('reports unavailable and never throws', () => {
+    const audio = new SimonAudio()
+    expect(audio.available).toBe(false)
+    expect(() => {
+      audio.resume()
+      audio.play(0)
+      audio.play(5, 100)
+      audio.dispose()
+    }).not.toThrow()
+  })
+
+  it('respects the muted flag as a plain toggle', () => {
+    const audio = new SimonAudio()
+    expect(audio.muted).toBe(false)
+    audio.muted = true
+    expect(() => audio.play(1)).not.toThrow()
+  })
+})

--- a/src/services/memoryAudio.ts
+++ b/src/services/memoryAudio.ts
@@ -1,0 +1,82 @@
+/**
+ * Simon pad tones for the Memory game's Simon mode.
+ *
+ * One frequency per pad; a short oscillator blip plays both when the computer
+ * shows the sequence and when the player taps a pad. Browsers block audio until
+ * a user gesture, so `resume()` (called from a click/tap) lazily creates and
+ * resumes the AudioContext. Everything degrades to a no-op where there is no
+ * AudioContext (unit tests / SSR), so callers never need to guard.
+ */
+
+/** Pentatonic-ish tones, one per pad index. Index 0..MAX_SIMON_PADS-1. */
+export const PAD_FREQUENCIES = [329.63, 261.63, 220.0, 164.81, 415.3, 493.88]
+
+type WebkitWindow = Window & { webkitAudioContext?: typeof AudioContext }
+
+function audioContextCtor(): typeof AudioContext | undefined {
+  if (typeof window === 'undefined') return undefined
+  return window.AudioContext ?? (window as WebkitWindow).webkitAudioContext
+}
+
+/**
+ * Thin wrapper over a single AudioContext. Construct once per view; call
+ * `resume()` from the first user gesture and `dispose()` on unmount.
+ */
+export class SimonAudio {
+  private ctx: AudioContext | null = null
+  muted = false
+
+  /** Whether real audio is available in this environment. */
+  get available(): boolean {
+    return audioContextCtor() !== undefined
+  }
+
+  /** Create the AudioContext (if needed) and resume it. Call from a gesture. */
+  resume(): void {
+    const Ctor = audioContextCtor()
+    if (!Ctor) return
+    if (!this.ctx) {
+      try {
+        this.ctx = new Ctor()
+      } catch {
+        this.ctx = null
+        return
+      }
+    }
+    if (this.ctx.state === 'suspended') void this.ctx.resume()
+  }
+
+  /** Play the tone for `pad` for `durationMs`. No-op when muted or unavailable. */
+  play(pad: number, durationMs = 300): void {
+    if (this.muted || !this.ctx) return
+    const freq = PAD_FREQUENCIES[pad % PAD_FREQUENCIES.length]
+    const now = this.ctx.currentTime
+    const end = now + durationMs / 1000
+
+    const osc = this.ctx.createOscillator()
+    const gain = this.ctx.createGain()
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(freq, now)
+
+    // Quick attack, gentle release so overlapping blips don't click.
+    gain.gain.setValueAtTime(0.0001, now)
+    gain.gain.exponentialRampToValueAtTime(0.2, now + 0.02)
+    gain.gain.exponentialRampToValueAtTime(0.0001, end)
+
+    osc.connect(gain).connect(this.ctx.destination)
+    osc.start(now)
+    osc.stop(end + 0.02)
+  }
+
+  /** Release the AudioContext. */
+  dispose(): void {
+    if (this.ctx) {
+      try {
+        void this.ctx.close()
+      } catch {
+        // ignore
+      }
+      this.ctx = null
+    }
+  }
+}

--- a/src/services/miniGolf.spec.ts
+++ b/src/services/miniGolf.spec.ts
@@ -65,6 +65,13 @@ describe('aimToVelocity', () => {
     expect(speed(aimToVelocity({ x: 0, y: 5 }, 5))).toBeCloseTo(MAX_POWER)
     expect(speed(aimToVelocity({ x: 0, y: 5 }, -1))).toBe(0)
   })
+  it('never exceeds MAX_POWER for an off-screen drag (power > 1)', () => {
+    // A drag that runs well beyond the canvas produces power far above 1; the
+    // launch speed must still cap at full power rather than growing unbounded.
+    for (const p of [1.5, 3, 100]) {
+      expect(speed(aimToVelocity({ x: 3, y: -4 }, p))).toBeCloseTo(MAX_POWER)
+    }
+  })
 })
 
 describe('inCup', () => {

--- a/src/services/miniGolf.spec.ts
+++ b/src/services/miniGolf.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BALL_RADIUS,
+  CAPTURE_SPEED,
+  MAX_POWER,
+  aimToVelocity,
+  atRest,
+  collide,
+  inCup,
+  makeHole,
+  speed,
+  step,
+  type BallState,
+  type Hole,
+} from './miniGolf'
+
+describe('collide (outer walls)', () => {
+  it('reflects off the left/right/top/bottom bounds', () => {
+    const left = collide({ p: { x: -0.1, y: 0.5 }, v: { x: -0.5, y: 0 } }, [])
+    expect(left.p.x).toBeCloseTo(BALL_RADIUS)
+    expect(left.v.x).toBeGreaterThan(0)
+
+    const bottom = collide({ p: { x: 0.5, y: 1.2 }, v: { x: 0, y: 0.5 } }, [])
+    expect(bottom.p.y).toBeCloseTo(1 - BALL_RADIUS)
+    expect(bottom.v.y).toBeLessThan(0)
+  })
+})
+
+describe('collide (inner walls)', () => {
+  const wall = { x: 0.4, y: 0.4, w: 0.2, h: 0.05 }
+  it('pushes the ball out and flips a velocity component on overlap', () => {
+    // Ball just above the wall moving down into it.
+    const s: BallState = { p: { x: 0.5, y: 0.4 + 0.01 }, v: { x: 0, y: -0.5 } }
+    const out = collide(s, [wall])
+    // Pushed above the wall, vertical velocity flips upward (positive is down here? no: y-down)
+    expect(out.p.y).toBeLessThanOrEqual(wall.y - BALL_RADIUS + 1e-9)
+  })
+  it('leaves a ball far from the wall untouched', () => {
+    const s: BallState = { p: { x: 0.1, y: 0.1 }, v: { x: 0.2, y: 0.2 } }
+    expect(collide(s, [wall])).toEqual(s)
+  })
+})
+
+describe('step', () => {
+  it('moves the ball and applies friction', () => {
+    const s: BallState = { p: { x: 0.5, y: 0.5 }, v: { x: 0.4, y: 0 } }
+    const next = step(s, [], 16)
+    expect(next.p.x).toBeGreaterThan(0.5)
+    expect(speed(next.v)).toBeLessThan(speed(s.v))
+  })
+  it('eventually comes to rest', () => {
+    let s: BallState = { p: { x: 0.5, y: 0.5 }, v: { x: 0.6, y: 0.3 } }
+    for (let i = 0; i < 600 && !atRest(s); i += 1) s = step(s, [], 16)
+    expect(atRest(s)).toBe(true)
+  })
+})
+
+describe('aimToVelocity', () => {
+  it('fires opposite the drag, scaled by power', () => {
+    const v = aimToVelocity({ x: 10, y: 0 }, 1) // dragged right → fire left
+    expect(v.x).toBeCloseTo(-MAX_POWER)
+    expect(v.y).toBeCloseTo(0)
+  })
+  it('clamps power to [0,1]', () => {
+    expect(speed(aimToVelocity({ x: 0, y: 5 }, 5))).toBeCloseTo(MAX_POWER)
+    expect(speed(aimToVelocity({ x: 0, y: 5 }, -1))).toBe(0)
+  })
+})
+
+describe('inCup', () => {
+  const hole: Hole = {
+    index: 0,
+    start: { x: 0.5, y: 0.86 },
+    cup: { x: 0.5, y: 0.12 },
+    cupRadius: 0.05,
+    walls: [],
+    par: 3,
+    seed: 's',
+  }
+  it('captures a slow ball over the cup', () => {
+    expect(inCup({ p: { x: 0.5, y: 0.12 }, v: { x: 0.1, y: 0 } }, hole)).toBe(true)
+  })
+  it('rejects a fast ball over the cup (lips out)', () => {
+    expect(inCup({ p: { x: 0.5, y: 0.12 }, v: { x: CAPTURE_SPEED + 0.1, y: 0 } }, hole)).toBe(false)
+  })
+  it('rejects a ball away from the cup', () => {
+    expect(inCup({ p: { x: 0.9, y: 0.9 }, v: { x: 0, y: 0 } }, hole)).toBe(false)
+  })
+})
+
+describe('makeHole', () => {
+  it('is deterministic and well-formed', () => {
+    for (let i = 0; i < 9; i += 1) {
+      const h = makeHole(i, 'course-1')
+      expect(makeHole(i, 'course-1')).toEqual(h)
+      expect(h.start.y).toBeGreaterThan(h.cup.y) // start below the cup (portrait)
+      expect(h.par).toBeGreaterThanOrEqual(2)
+      expect(h.walls.length).toBeGreaterThanOrEqual(1)
+      for (const w of h.walls) {
+        expect(w.x).toBeGreaterThanOrEqual(0)
+        expect(w.x + w.w).toBeLessThanOrEqual(1.0001)
+      }
+    }
+  })
+})

--- a/src/services/miniGolf.ts
+++ b/src/services/miniGolf.ts
@@ -100,6 +100,10 @@ export function collide(state: BallState, walls: Rect[]): BallState {
     }
   }
 
+  // Re-clamp: pushing out of an inner wall must never leave the play area.
+  px = Math.max(r, Math.min(1 - r, px))
+  py = Math.max(r, Math.min(1 - r, py))
+
   return { p: { x: px, y: py }, v: { x: vx, y: vy } }
 }
 

--- a/src/services/miniGolf.ts
+++ b/src/services/miniGolf.ts
@@ -1,0 +1,165 @@
+/**
+ * Mini Golf — physics and course generation, pure and testable. The view drives
+ * a fixed-timestep simulation and renders; this module owns the ball integrator,
+ * wall reflection, hole capture, and seeded hole layouts.
+ *
+ * Coordinates are fractions of the play area: x,y in [0,1]. The course is taller
+ * than wide (portrait). Velocities are per second.
+ */
+
+import { rngFromSeed } from './seed'
+
+export interface Vec {
+  x: number
+  y: number
+}
+
+export interface BallState {
+  p: Vec
+  v: Vec
+}
+
+/** An axis-aligned wall rectangle the ball bounces off (fractions of the area). */
+export interface Rect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface Hole {
+  index: number
+  start: Vec
+  cup: Vec
+  cupRadius: number
+  walls: Rect[]
+  par: number
+  seed: string
+}
+
+export const BALL_RADIUS = 0.022
+export const FRICTION = 1.2 // velocity halving-ish drag per second (see step)
+export const STOP_SPEED = 0.02 // below this the ball is considered at rest
+export const MAX_POWER = 1.6 // max launch speed from a full-strength stroke
+export const CAPTURE_SPEED = 0.9 // ball must be slower than this to drop in the cup
+
+const clamp01 = (v: number, r: number) => Math.max(r, Math.min(1 - r, v))
+
+/** Reflect the ball off the outer bounds and any wall rectangles (one step). */
+export function collide(state: BallState, walls: Rect[]): BallState {
+  let { x: px, y: py } = state.p
+  let { x: vx, y: vy } = state.v
+  const r = BALL_RADIUS
+
+  // Outer walls
+  if (px < r) {
+    px = r
+    vx = Math.abs(vx)
+  } else if (px > 1 - r) {
+    px = 1 - r
+    vx = -Math.abs(vx)
+  }
+  if (py < r) {
+    py = r
+    vy = Math.abs(vy)
+  } else if (py > 1 - r) {
+    py = 1 - r
+    vy = -Math.abs(vy)
+  }
+
+  // Inner wall rectangles: push the ball out along the shallowest axis and flip
+  // that velocity component.
+  for (const w of walls) {
+    const nearestX = Math.max(w.x, Math.min(px, w.x + w.w))
+    const nearestY = Math.max(w.y, Math.min(py, w.y + w.h))
+    const dx = px - nearestX
+    const dy = py - nearestY
+    if (dx * dx + dy * dy >= r * r) continue // no overlap
+
+    // Determine penetration on each axis to pick the reflection normal.
+    const overlapLeft = px - w.x
+    const overlapRight = w.x + w.w - px
+    const overlapTop = py - w.y
+    const overlapBottom = w.y + w.h - py
+    const minX = Math.min(overlapLeft, overlapRight)
+    const minY = Math.min(overlapTop, overlapBottom)
+    if (minX < minY) {
+      if (overlapLeft < overlapRight) {
+        px = w.x - r
+        vx = -Math.abs(vx)
+      } else {
+        px = w.x + w.w + r
+        vx = Math.abs(vx)
+      }
+    } else if (overlapTop < overlapBottom) {
+      py = w.y - r
+      vy = -Math.abs(vy)
+    } else {
+      py = w.y + w.h + r
+      vy = Math.abs(vy)
+    }
+  }
+
+  return { p: { x: px, y: py }, v: { x: vx, y: vy } }
+}
+
+/** Advance the ball one fixed step: integrate, apply friction, then collide. */
+export function step(state: BallState, walls: Rect[], dtMs: number): BallState {
+  const dt = dtMs / 1000
+  const moved: BallState = {
+    p: { x: state.p.x + state.v.x * dt, y: state.p.y + state.v.y * dt },
+    v: { x: state.v.x, y: state.v.y },
+  }
+  // Exponential friction.
+  const decay = Math.exp(-FRICTION * dt)
+  moved.v.x *= decay
+  moved.v.y *= decay
+  return collide(moved, walls)
+}
+
+export const speed = (v: Vec): number => Math.hypot(v.x, v.y)
+export const atRest = (state: BallState): boolean => speed(state.v) < STOP_SPEED
+
+/** Whether the ball is over the cup and slow enough to be captured. */
+export function inCup(state: BallState, hole: Hole): boolean {
+  const dx = state.p.x - hole.cup.x
+  const dy = state.p.y - hole.cup.y
+  return Math.hypot(dx, dy) < hole.cupRadius && speed(state.v) < CAPTURE_SPEED
+}
+
+/**
+ * Build a launch velocity from an aim vector (drag from the ball). `power` is
+ * 0..1 of MAX_POWER; the ball fires opposite the drag (pull-back-to-shoot).
+ */
+export function aimToVelocity(drag: Vec, power: number): Vec {
+  const len = Math.hypot(drag.x, drag.y) || 1
+  const p = Math.max(0, Math.min(1, power)) * MAX_POWER
+  return { x: (-drag.x / len) * p, y: (-drag.y / len) * p }
+}
+
+/** Generate a deterministic hole: start near the bottom, cup near the top, with
+ *  a couple of wall obstacles in between. */
+export function makeHole(index: number, seed: string): Hole {
+  const rng = rngFromSeed(`golf:${seed}:${index}`)
+  const start: Vec = { x: clamp01(0.3 + rng() * 0.4, BALL_RADIUS), y: 0.86 }
+  const cup: Vec = { x: clamp01(0.25 + rng() * 0.5, 0.05), y: 0.12 }
+
+  const wallCount = 1 + Math.min(3, Math.floor(index / 2) + Math.floor(rng() * 2))
+  const walls: Rect[] = []
+  for (let i = 0; i < wallCount; i += 1) {
+    const horizontal = rng() < 0.6
+    const band = 0.28 + (i / Math.max(1, wallCount)) * 0.42 + rng() * 0.06 // y position, mid-course
+    if (horizontal) {
+      const w = 0.3 + rng() * 0.4
+      walls.push({ x: clamp01(rng() * (1 - w), 0) , y: band, w, h: 0.035 })
+    } else {
+      const h = 0.16 + rng() * 0.2
+      walls.push({ x: 0.2 + rng() * 0.6, y: band - h / 2, w: 0.035, h })
+    }
+  }
+
+  const par = 2 + Math.floor(index / 3) + (wallCount >= 3 ? 1 : 0)
+  return { index, start, cup, cupRadius: 0.05, walls, par, seed }
+}
+
+export const COURSE_HOLES = 9

--- a/src/services/nerdle.spec.ts
+++ b/src/services/nerdle.spec.ts
@@ -83,4 +83,12 @@ describe('generateEquation', () => {
   it('exposes a sane guess limit', () => {
     expect(MAX_GUESSES).toBeGreaterThan(0)
   })
+  it('can produce every operator as the answer across seeds', () => {
+    const ops = new Set<string>()
+    for (let i = 0; i < 400; i += 1) {
+      const eq = generateEquation(`op-scan-${i}`)
+      for (const ch of ['+', '-', '*', '/']) if (eq.includes(ch)) ops.add(ch)
+    }
+    expect(ops.has('/')).toBe(true) // division must be reachable (regression guard)
+  })
 })

--- a/src/services/nerdle.spec.ts
+++ b/src/services/nerdle.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MAX_GUESSES,
+  WIDTH,
+  generateEquation,
+  isValidEquation,
+  mergeKeyStatuses,
+  scoreGuess,
+  type TileStatus,
+} from './nerdle'
+
+describe('isValidEquation', () => {
+  it('accepts a true, well-formed equation', () => {
+    expect(isValidEquation('48-36=12')).toBe(true)
+    expect(isValidEquation('12+13=25')).toBe(true)
+    expect(isValidEquation('10-2=008')).toBe(false) // leading zero on rhs
+  })
+  it('respects operator precedence', () => {
+    expect(isValidEquation('2+3*4=14')).toBe(true) // 2 + 12
+    expect(isValidEquation('2+3*4=20')).toBe(false)
+  })
+  it('rejects false equations', () => {
+    expect(isValidEquation('48-36=13')).toBe(false)
+    expect(isValidEquation('12+13=99')).toBe(false)
+  })
+  it('rejects the wrong width', () => {
+    expect(isValidEquation('1+1=2')).toBe(false) // too short
+    expect('48-36=12').toHaveLength(WIDTH)
+  })
+  it('rejects malformed strings', () => {
+    expect(isValidEquation('1++12=25')).toBe(false) // consecutive operators
+    expect(isValidEquation('1+2=3=99')).toBe(false) // two equals
+    expect(isValidEquation('*9+9=990')).toBe(false) // leading operator
+  })
+  it('rejects leading zeros in operands', () => {
+    expect(isValidEquation('08+2=010')).toBe(false)
+  })
+})
+
+describe('scoreGuess', () => {
+  it('marks all correct for an exact match', () => {
+    expect(scoreGuess('9*8=72', '9*8=72')).toEqual<TileStatus[]>([
+      'correct', 'correct', 'correct', 'correct', 'correct', 'correct',
+    ])
+  })
+  it('marks present for right symbol, wrong place', () => {
+    // answer 12+34, guess 34+12 → the digits exist but shifted
+    const res = scoreGuess('34+12', '12+34')
+    expect(res[2]).toBe('correct') // '+' aligns
+    expect(res[0]).toBe('present') // '3' present elsewhere
+  })
+  it('does not over-count duplicates beyond the answer', () => {
+    // answer has one '1'; guess has two '1's — only one should be present/correct
+    const res = scoreGuess('11+0=1', '1+9=10')
+    const ones = res.filter((s, i) => '11+0=1'[i] === '1')
+    const credited = ones.filter((s) => s !== 'absent').length
+    const answerOnes = [...'1+9=10'].filter((c) => c === '1').length
+    expect(credited).toBeLessThanOrEqual(answerOnes)
+  })
+})
+
+describe('mergeKeyStatuses', () => {
+  it('upgrades a key status but never downgrades', () => {
+    let keys: Record<string, TileStatus> = {}
+    keys = mergeKeyStatuses(keys, '1+2=3x', ['present', 'absent', 'absent', 'absent', 'absent', 'absent'])
+    expect(keys['1']).toBe('present')
+    keys = mergeKeyStatuses(keys, '1+2=3x', ['correct', 'absent', 'absent', 'absent', 'absent', 'absent'])
+    expect(keys['1']).toBe('correct')
+    keys = mergeKeyStatuses(keys, '1+2=3x', ['present', 'absent', 'absent', 'absent', 'absent', 'absent'])
+    expect(keys['1']).toBe('correct') // not downgraded back to present
+  })
+})
+
+describe('generateEquation', () => {
+  it('is deterministic and valid for a seed', () => {
+    for (const seed of ['a', 'b', 'c', 'seed-123', 'x']) {
+      const eq = generateEquation(seed)
+      expect(eq).toHaveLength(WIDTH)
+      expect(isValidEquation(eq)).toBe(true)
+      expect(generateEquation(seed)).toBe(eq) // deterministic
+    }
+  })
+  it('exposes a sane guess limit', () => {
+    expect(MAX_GUESSES).toBeGreaterThan(0)
+  })
+})

--- a/src/services/nerdle.ts
+++ b/src/services/nerdle.ts
@@ -126,8 +126,9 @@ export function generateEquation(seed: string): string {
     let a: number
     let b: number
     if (op === '/') {
-      // Build a clean division: b * quotient = a.
-      b = randInt(rng, 1, 9)
+      // Build a clean division a/b=q. Wide operand range so the string can
+      // actually reach WIDTH (small operands cap the dividend too low).
+      b = randInt(rng, 1, 99)
       const q = randInt(rng, 1, 9)
       a = b * q
     } else {

--- a/src/services/nerdle.ts
+++ b/src/services/nerdle.ts
@@ -1,0 +1,161 @@
+/**
+ * Nerdle engine — a Wordle for arithmetic. The hidden answer is a valid
+ * equation of fixed width (default 8) using digits 0-9 and + - * / =, e.g.
+ * "9*8=72". Guesses are scored per tile as correct / present / absent, with the
+ * same duplicate-aware counting Wordle uses.
+ */
+
+import { rngFromSeed } from './seed'
+
+export const WIDTH = 8
+export const MAX_GUESSES = 6
+
+export type TileStatus = 'correct' | 'present' | 'absent'
+export const OPERATORS = ['+', '-', '*', '/'] as const
+export const KEYS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '-', '*', '/', '='] as const
+
+/**
+ * Evaluate the left side of an equation string with correct operator
+ * precedence (× and ÷ before + and −); null if malformed. Hand-rolled rather
+ * than eval'd, so there's no code execution on user input.
+ */
+function evalExpr(expr: string): number | null {
+  if (!/^[0-9+\-*/]+$/.test(expr)) return null
+  if (/[+\-*/]{2,}/.test(expr)) return null // no consecutive operators
+  if (/^[+\-*/]/.test(expr) || /[+\-*/]$/.test(expr)) return null // no leading/trailing op
+  // Disallow multi-digit numbers with a leading zero (e.g. "08"), matching Nerdle.
+  if (/(^|[+\-*/])0\d/.test(expr)) return null
+
+  const tokens = expr.match(/\d+|[+\-*/]/g)
+  if (!tokens || tokens.length % 2 === 0) return null
+
+  // First pass: fold * and / into a list of terms joined by + / -.
+  const terms: number[] = [Number(tokens[0])]
+  const addOps: string[] = []
+  for (let k = 1; k < tokens.length; k += 2) {
+    const op = tokens[k]
+    const num = Number(tokens[k + 1])
+    if (op === '*') {
+      terms[terms.length - 1] *= num
+    } else if (op === '/') {
+      if (num === 0) return null
+      terms[terms.length - 1] /= num
+    } else {
+      addOps.push(op)
+      terms.push(num)
+    }
+  }
+
+  let result = terms[0]
+  for (let k = 0; k < addOps.length; k += 1) {
+    result += addOps[k] === '+' ? terms[k + 1] : -terms[k + 1]
+  }
+  return Number.isFinite(result) ? result : null
+}
+
+/** Whether a full "a=b" string is a syntactically valid, true equation. */
+export function isValidEquation(guess: string): boolean {
+  if (guess.length !== WIDTH) return false
+  const parts = guess.split('=')
+  if (parts.length !== 2) return false
+  const [lhs, rhs] = parts
+  if (lhs.length === 0 || rhs.length === 0) return false
+  // The right side must be a plain non-negative integer (standard Nerdle).
+  if (!/^\d+$/.test(rhs)) return false
+  if (/^0\d/.test(rhs)) return false
+  const left = evalExpr(lhs)
+  if (left === null) return false
+  return left === Number(rhs)
+}
+
+/**
+ * Score a guess against the answer, Wordle-style: greens first, then greens are
+ * removed from the pool before assigning yellows so duplicate symbols don't
+ * over-count.
+ */
+export function scoreGuess(guess: string, answer: string): TileStatus[] {
+  const result: TileStatus[] = new Array(guess.length).fill('absent')
+  const counts: Record<string, number> = {}
+  for (const ch of answer) counts[ch] = (counts[ch] ?? 0) + 1
+
+  for (let i = 0; i < guess.length; i += 1) {
+    if (guess[i] === answer[i]) {
+      result[i] = 'correct'
+      counts[guess[i]] -= 1
+    }
+  }
+  for (let i = 0; i < guess.length; i += 1) {
+    if (result[i] === 'correct') continue
+    const ch = guess[i]
+    if (counts[ch] > 0) {
+      result[i] = 'present'
+      counts[ch] -= 1
+    }
+  }
+  return result
+}
+
+/** Merge per-guess tile statuses into the best-known status for each key. */
+export function mergeKeyStatuses(
+  current: Record<string, TileStatus>,
+  guess: string,
+  statuses: TileStatus[],
+): Record<string, TileStatus> {
+  const rank: Record<TileStatus, number> = { absent: 0, present: 1, correct: 2 }
+  const next = { ...current }
+  guess.split('').forEach((ch, i) => {
+    const s = statuses[i]
+    if (next[ch] === undefined || rank[s] > rank[next[ch]]) next[ch] = s
+  })
+  return next
+}
+
+const randInt = (rng: () => number, min: number, max: number): number =>
+  min + Math.floor(rng() * (max - min + 1))
+
+/**
+ * Generate a valid equation of exactly WIDTH characters from a seed. Tries
+ * random operand/operator combinations until one fits the width and all Nerdle
+ * validity rules (integer result, no leading zeros, etc.).
+ */
+export function generateEquation(seed: string): string {
+  const rng = rngFromSeed(`nerdle:${seed}`)
+
+  for (let attempt = 0; attempt < 5000; attempt += 1) {
+    const op = OPERATORS[randInt(rng, 0, OPERATORS.length - 1)]
+    let a: number
+    let b: number
+    if (op === '/') {
+      // Build a clean division: b * quotient = a.
+      b = randInt(rng, 1, 9)
+      const q = randInt(rng, 1, 9)
+      a = b * q
+    } else {
+      a = randInt(rng, 1, 99)
+      b = randInt(rng, 1, 99)
+      if (op === '-' && b > a) [a, b] = [b, a] // keep the result non-negative
+    }
+
+    let value: number
+    switch (op) {
+      case '+':
+        value = a + b
+        break
+      case '-':
+        value = a - b
+        break
+      case '*':
+        value = a * b
+        break
+      default:
+        value = a / b
+    }
+    if (!Number.isInteger(value) || value < 0) continue
+
+    const candidate = `${a}${op}${b}=${value}`
+    if (candidate.length === WIDTH && isValidEquation(candidate)) return candidate
+  }
+
+  // Deterministic fallback that always fits WIDTH=8 (extremely unlikely to hit).
+  return '12+13=25'
+}

--- a/src/services/nonogram.spec.ts
+++ b/src/services/nonogram.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import {
+  colClues,
+  generateNonogram,
+  isSolved,
+  lineClue,
+  lineSatisfied,
+  rowClues,
+  type Solution,
+} from './nonogram'
+
+describe('lineClue', () => {
+  it('counts consecutive runs', () => {
+    expect(lineClue([true, true, false, true])).toEqual([2, 1])
+    expect(lineClue([false, true, true, true])).toEqual([3])
+    expect(lineClue([true, false, true, false, true])).toEqual([1, 1, 1])
+  })
+  it('clues an empty line to [0]', () => {
+    expect(lineClue([false, false, false])).toEqual([0])
+  })
+  it('clues a full line to its length', () => {
+    expect(lineClue([true, true, true])).toEqual([3])
+  })
+})
+
+describe('rowClues / colClues', () => {
+  // 3x3:
+  //  X . X
+  //  X X .
+  //  . . X
+  const grid: Solution = [true, false, true, true, true, false, false, false, true]
+  it('derives row clues', () => {
+    expect(rowClues(grid, 3, 3)).toEqual([[1, 1], [2], [1]])
+  })
+  it('derives column clues', () => {
+    expect(colClues(grid, 3, 3)).toEqual([[2], [1], [1, 1]])
+  })
+})
+
+describe('generateNonogram', () => {
+  it('is deterministic for a given size + seed', () => {
+    const a = generateNonogram(5, 5, 'seed-1')
+    const b = generateNonogram(5, 5, 'seed-1')
+    expect(a.solution).toEqual(b.solution)
+    expect(a.rowClues).toEqual(b.rowClues)
+  })
+  it('produces clues consistent with its own solution', () => {
+    const p = generateNonogram(8, 8, 'abc')
+    expect(p.rowClues).toEqual(rowClues(p.solution, 8, 8))
+    expect(p.colClues).toEqual(colClues(p.solution, 8, 8))
+  })
+  it('is never entirely empty', () => {
+    const p = generateNonogram(5, 5, 'x')
+    expect(p.solution.some(Boolean)).toBe(true)
+  })
+})
+
+describe('isSolved', () => {
+  it('accepts the generating solution', () => {
+    const p = generateNonogram(6, 6, 'solve-me')
+    expect(isSolved(p.solution, p)).toBe(true)
+  })
+  it('rejects an incomplete grid', () => {
+    const p = generateNonogram(6, 6, 'solve-me')
+    const partial = p.solution.slice()
+    const firstFilled = partial.indexOf(true)
+    partial[firstFilled] = false
+    expect(isSolved(partial, p)).toBe(false)
+  })
+  it('accepts any grid whose clues match (clue-based, not cell-based)', () => {
+    // A symmetric picture where the mirror image satisfies the same clues.
+    //  X .        . X
+    //  X .   vs   . X   → both rows clue [1], both cols clue [2],[0]... differ,
+    // so instead use a case that IS clue-equivalent:
+    //  X X        X X
+    //  . .   ==   . .   (identical) — trivial accept
+    const p = generateNonogram(4, 4, 'clue')
+    expect(isSolved(p.solution.slice(), p)).toBe(true)
+  })
+})
+
+describe('lineSatisfied', () => {
+  it('matches a line against a clue', () => {
+    expect(lineSatisfied([true, true, false, true], [2, 1])).toBe(true)
+    expect(lineSatisfied([true, false, false, true], [2, 1])).toBe(false)
+    expect(lineSatisfied([false, false], [0])).toBe(true)
+  })
+})

--- a/src/services/nonogram.spec.ts
+++ b/src/services/nonogram.spec.ts
@@ -5,9 +5,12 @@ import {
   isSolved,
   lineClue,
   lineSatisfied,
+  nonogramFromPattern,
+  patternToSolution,
   rowClues,
   type Solution,
 } from './nonogram'
+import { NONOGRAM_PATTERNS, patternById, patternsForSize } from './nonogramPatterns'
 
 describe('lineClue', () => {
   it('counts consecutive runs', () => {
@@ -76,6 +79,55 @@ describe('isSolved', () => {
     //  . .   ==   . .   (identical) — trivial accept
     const p = generateNonogram(4, 4, 'clue')
     expect(isSolved(p.solution.slice(), p)).toBe(true)
+  })
+})
+
+describe('pattern library', () => {
+  it('bundles pictures across the supported sizes', () => {
+    expect(NONOGRAM_PATTERNS.length).toBeGreaterThanOrEqual(8)
+    for (const size of [5, 10, 15]) {
+      expect(patternsForSize(size).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('every pattern is a well-formed square with a non-empty picture and unique id', () => {
+    const ids = new Set<string>()
+    for (const p of NONOGRAM_PATTERNS) {
+      expect(p.rows.length, `${p.id} row count`).toBe(p.size)
+      for (const line of p.rows) {
+        expect(line.length, `${p.id} row width`).toBe(p.size)
+      }
+      const sol = patternToSolution(p)
+      expect(sol.length).toBe(p.size * p.size)
+      expect(sol.some(Boolean), `${p.id} not empty`).toBe(true)
+      expect(ids.has(p.id), `${p.id} unique`).toBe(false)
+      ids.add(p.id)
+    }
+  })
+
+  it('patternToSolution maps "#" to filled, row-major', () => {
+    const grid = patternToSolution({ id: 't', name: 't', size: 3, rows: ['#..', '.#.', '..#'] })
+    expect(grid).toEqual([true, false, false, false, true, false, false, false, true])
+  })
+
+  it('derives clues from the chosen picture', () => {
+    // A 5×5 heart — check its clues match the run-lengths of the drawn grid.
+    const heart = patternById('heart5', 5)!
+    const nono = nonogramFromPattern(heart)
+    expect(nono.rows).toBe(5)
+    expect(nono.cols).toBe(5)
+    expect(nono.rowClues).toEqual(rowClues(nono.solution, 5, 5))
+    expect(nono.colClues).toEqual(colClues(nono.solution, 5, 5))
+    // Heart rows: '.#.#.', '#####', '#####', '.###.', '..#..'
+    expect(nono.rowClues).toEqual([[1, 1], [5], [5], [3], [1]])
+    expect(nono.colClues).toEqual([[2], [4], [4], [4], [2]])
+  })
+
+  it('produces a puzzle solved by its own picture, for every pattern', () => {
+    for (const p of NONOGRAM_PATTERNS) {
+      const nono = nonogramFromPattern(p)
+      expect(isSolved(nono.solution, nono), `${p.id} solvable`).toBe(true)
+    }
   })
 })
 

--- a/src/services/nonogram.ts
+++ b/src/services/nonogram.ts
@@ -20,6 +20,18 @@ export interface Nonogram {
   seed: string
 }
 
+/**
+ * A hand-authored picture. `rows` are drawn as text (see nonogramPatterns): `#`
+ * is a filled cell, any other character empty. Every row must be `size` chars
+ * and there must be `size` rows.
+ */
+export interface NonogramPattern {
+  id: string
+  name: string
+  size: number
+  rows: string[]
+}
+
 /** Run-lengths of consecutive `true`s in a line. An empty line clues to [0]. */
 export function lineClue(line: boolean[]): number[] {
   const runs: number[] = []
@@ -74,6 +86,29 @@ export function generateNonogram(rows: number, cols: number, seed: string): Nono
     rowClues: rowClues(solution, rows, cols),
     colClues: colClues(solution, rows, cols),
     seed,
+  }
+}
+
+/** Turn a text picture (`#` = filled) into a row-major boolean solution grid. */
+export function patternToSolution(pattern: NonogramPattern): Solution {
+  return pattern.rows.flatMap((line) => Array.from(line, (ch) => ch === '#'))
+}
+
+/**
+ * Build a solvable puzzle from a hand-authored picture: the picture is the
+ * solution, and its clues are derived from it. Deterministic — the seed is the
+ * pattern id so the URL stays shareable.
+ */
+export function nonogramFromPattern(pattern: NonogramPattern): Nonogram {
+  const { size } = pattern
+  const solution = patternToSolution(pattern)
+  return {
+    rows: size,
+    cols: size,
+    solution,
+    rowClues: rowClues(solution, size, size),
+    colClues: colClues(solution, size, size),
+    seed: `@${pattern.id}`,
   }
 }
 

--- a/src/services/nonogram.ts
+++ b/src/services/nonogram.ts
@@ -1,0 +1,103 @@
+/**
+ * Nonogram (Picross) engine — generate a seeded puzzle from a random picture,
+ * derive its row/column clues, and check line/solve validity. Pure and
+ * deterministic so a puzzle is shareable from its seed.
+ *
+ * The solution is a boolean grid (true = filled). Clues are the run-lengths of
+ * consecutive filled cells in each row and column, e.g. [2, 1].
+ */
+
+import { rngFromSeed } from './seed'
+
+export type Solution = boolean[] // length rows*cols, row-major
+
+export interface Nonogram {
+  rows: number
+  cols: number
+  solution: Solution
+  rowClues: number[][]
+  colClues: number[][]
+  seed: string
+}
+
+/** Run-lengths of consecutive `true`s in a line. An empty line clues to [0]. */
+export function lineClue(line: boolean[]): number[] {
+  const runs: number[] = []
+  let run = 0
+  for (const filled of line) {
+    if (filled) {
+      run += 1
+    } else if (run > 0) {
+      runs.push(run)
+      run = 0
+    }
+  }
+  if (run > 0) runs.push(run)
+  return runs.length ? runs : [0]
+}
+
+const row = (grid: Solution, cols: number, r: number): boolean[] =>
+  grid.slice(r * cols, (r + 1) * cols)
+
+const col = (grid: Solution, rows: number, cols: number, c: number): boolean[] => {
+  const out: boolean[] = []
+  for (let r = 0; r < rows; r += 1) out.push(grid[r * cols + c])
+  return out
+}
+
+export function rowClues(grid: Solution, rows: number, cols: number): number[][] {
+  return Array.from({ length: rows }, (_, r) => lineClue(row(grid, cols, r)))
+}
+
+export function colClues(grid: Solution, rows: number, cols: number): number[][] {
+  return Array.from({ length: cols }, (_, c) => lineClue(col(grid, rows, cols, c)))
+}
+
+/**
+ * Generate a puzzle by randomly filling cells (biased ~55% so pictures aren't
+ * too sparse), then deriving clues. Re-rolls the rare all-empty grid.
+ */
+export function generateNonogram(rows: number, cols: number, seed: string): Nonogram {
+  const rng = rngFromSeed(`${rows}x${cols}:${seed}`)
+  let solution: Solution
+  let salt = 0
+  do {
+    const r = salt === 0 ? rng : rngFromSeed(`${rows}x${cols}:${seed}:${salt}`)
+    solution = Array.from({ length: rows * cols }, () => r() < 0.55)
+    salt += 1
+  } while (solution.every((v) => !v))
+
+  return {
+    rows,
+    cols,
+    solution,
+    rowClues: rowClues(solution, rows, cols),
+    colClues: colClues(solution, rows, cols),
+    seed,
+  }
+}
+
+/**
+ * Whether the player's filled cells satisfy all clues. A nonogram is solved when
+ * every row and column clue matches — which can be true for a different-looking
+ * grid than `solution` when the puzzle isn't uniquely determined, so we check
+ * clues rather than exact cell equality.
+ */
+export function isSolved(marks: boolean[], puzzle: Nonogram): boolean {
+  const { rows, cols, rowClues: rc, colClues: cc } = puzzle
+  for (let r = 0; r < rows; r += 1) {
+    if (!clueEquals(lineClue(row(marks, cols, r)), rc[r])) return false
+  }
+  for (let c = 0; c < cols; c += 1) {
+    if (!clueEquals(lineClue(col(marks, rows, cols, c)), cc[c])) return false
+  }
+  return true
+}
+
+const clueEquals = (a: number[], b: number[]): boolean =>
+  a.length === b.length && a.every((v, i) => v === b[i])
+
+/** Whether a single line of marks already satisfies its clue (for row/col ticks). */
+export function lineSatisfied(line: boolean[], clue: number[]): boolean {
+  return clueEquals(lineClue(line), clue)
+}

--- a/src/services/nonogramPatterns.ts
+++ b/src/services/nonogramPatterns.ts
@@ -1,0 +1,256 @@
+/**
+ * Hand-authored pixel-art picture library for the Nonogram game.
+ *
+ * Each pattern is a square grid drawn as text rows so it stays readable and
+ * editable here: `#` is a filled cell, any other character (`.`) is empty. The
+ * game derives the row/column clues from the grid (see `nonogramFromPattern`),
+ * so every pattern is trivially solvable — its own picture is a valid solution.
+ *
+ * Patterns are grouped by side length so the picker can offer only the ones
+ * that fit the current board size. Fully self-contained — no network.
+ */
+import type { NonogramPattern } from './nonogram'
+
+/** 5×5 pictures — bold, single-glance shapes. */
+const P5: NonogramPattern[] = [
+  {
+    id: 'heart5',
+    name: 'Heart',
+    size: 5,
+    rows: [
+      '.#.#.',
+      '#####',
+      '#####',
+      '.###.',
+      '..#..',
+    ],
+  },
+  {
+    id: 'diamond5',
+    name: 'Diamond',
+    size: 5,
+    rows: [
+      '..#..',
+      '.###.',
+      '#####',
+      '.###.',
+      '..#..',
+    ],
+  },
+  {
+    id: 'plus5',
+    name: 'Plus',
+    size: 5,
+    rows: [
+      '..#..',
+      '..#..',
+      '#####',
+      '..#..',
+      '..#..',
+    ],
+  },
+  {
+    id: 'x5',
+    name: 'Cross X',
+    size: 5,
+    rows: [
+      '#...#',
+      '.#.#.',
+      '..#..',
+      '.#.#.',
+      '#...#',
+    ],
+  },
+]
+
+/** 10×10 pictures. */
+const P10: NonogramPattern[] = [
+  {
+    id: 'heart10',
+    name: 'Heart',
+    size: 10,
+    rows: [
+      '..........',
+      '.##....##.',
+      '##########',
+      '##########',
+      '##########',
+      '.########.',
+      '..######..',
+      '...####...',
+      '....##....',
+      '..........',
+    ],
+  },
+  {
+    id: 'invader10',
+    name: 'Space Invader',
+    size: 10,
+    rows: [
+      '..........',
+      '..#....#..',
+      '...#..#...',
+      '..######..',
+      '.##.##.##.',
+      '##########',
+      '#.######.#',
+      '#.#....#.#',
+      '...#..#...',
+      '..#....#..',
+    ],
+  },
+  {
+    id: 'plus10',
+    name: 'Plus',
+    size: 10,
+    rows: [
+      '....##....',
+      '....##....',
+      '....##....',
+      '....##....',
+      '##########',
+      '##########',
+      '....##....',
+      '....##....',
+      '....##....',
+      '....##....',
+    ],
+  },
+  {
+    id: 'smiley10',
+    name: 'Smiley',
+    size: 10,
+    rows: [
+      '..######..',
+      '.########.',
+      '###.##.###',
+      '###.##.###',
+      '##########',
+      '##########',
+      '#.######.#',
+      '##.####.##',
+      '.########.',
+      '..######..',
+    ],
+  },
+  {
+    id: 'note10',
+    name: 'Music Note',
+    size: 10,
+    rows: [
+      '...######.',
+      '...#....#.',
+      '...#....#.',
+      '...#....#.',
+      '...#....#.',
+      '.###..###.',
+      '####..####',
+      '.##....##.',
+      '..........',
+      '..........',
+    ],
+  },
+]
+
+/** 15×15 pictures. */
+const P15: NonogramPattern[] = [
+  {
+    id: 'heart15',
+    name: 'Heart',
+    size: 15,
+    rows: [
+      '...............',
+      '..###.....###..',
+      '.#####...#####.',
+      '.#############.',
+      '.#############.',
+      '.#############.',
+      '.#############.',
+      '..###########..',
+      '...#########...',
+      '....#######....',
+      '.....#####.....',
+      '......###......',
+      '.......#.......',
+      '...............',
+      '...............',
+    ],
+  },
+  {
+    id: 'diamond15',
+    name: 'Diamond',
+    size: 15,
+    rows: [
+      '.......#.......',
+      '......###......',
+      '.....#####.....',
+      '....#######....',
+      '...#########...',
+      '..###########..',
+      '.#############.',
+      '###############',
+      '.#############.',
+      '..###########..',
+      '...#########...',
+      '....#######....',
+      '.....#####.....',
+      '......###......',
+      '.......#.......',
+    ],
+  },
+  {
+    id: 'mushroom15',
+    name: 'Mushroom',
+    size: 15,
+    rows: [
+      '...............',
+      '....#######....',
+      '..###########..',
+      '.#############.',
+      '###############',
+      '###############',
+      '.#############.',
+      '..###########..',
+      '.....#####.....',
+      '.....#####.....',
+      '.....#####.....',
+      '.....#####.....',
+      '....#######....',
+      '....#######....',
+      '...............',
+    ],
+  },
+  {
+    id: 'invader15',
+    name: 'Space Invader',
+    size: 15,
+    rows: [
+      '...............',
+      '...............',
+      '...............',
+      '....#.....#....',
+      '.....#...#.....',
+      '....#######....',
+      '...##.###.##...',
+      '..###########..',
+      '..#.#######.#..',
+      '..#.#.....#.#..',
+      '.....##.##.....',
+      '...............',
+      '...............',
+      '...............',
+      '...............',
+    ],
+  },
+]
+
+/** All bundled pictures, across every supported board size. */
+export const NONOGRAM_PATTERNS: NonogramPattern[] = [...P5, ...P10, ...P15]
+
+/** Pictures that fit a given square board size. */
+export const patternsForSize = (size: number): NonogramPattern[] =>
+  NONOGRAM_PATTERNS.filter((p) => p.size === size)
+
+/** Look up a picture by its id (optionally constrained to a board size). */
+export const patternById = (id: string, size?: number): NonogramPattern | undefined =>
+  NONOGRAM_PATTERNS.find((p) => p.id === id && (size === undefined || p.size === size))

--- a/src/services/sudoku.spec.ts
+++ b/src/services/sudoku.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CELLS,
+  N,
+  countSolutions,
+  findConflicts,
+  generatePuzzle,
+  generateSolved,
+  isComplete,
+  isValidPlacement,
+  solve,
+  usedValues,
+  type Grid,
+  type Difficulty,
+} from './sudoku'
+
+const isValidSolution = (grid: Grid): boolean => {
+  if (grid.some((v) => v < 1 || v > 9)) return false
+  const unit = (cells: number[]) => new Set(cells).size === N
+  for (let r = 0; r < N; r += 1) {
+    const row: number[] = []
+    const col: number[] = []
+    for (let c = 0; c < N; c += 1) {
+      row.push(grid[r * N + c])
+      col.push(grid[c * N + r])
+    }
+    if (!unit(row) || !unit(col)) return false
+  }
+  for (let br = 0; br < 3; br += 1) {
+    for (let bc = 0; bc < 3; bc += 1) {
+      const box: number[] = []
+      for (let dr = 0; dr < 3; dr += 1) {
+        for (let dc = 0; dc < 3; dc += 1) box.push(grid[(br * 3 + dr) * N + (bc * 3 + dc)])
+      }
+      if (!unit(box)) return false
+    }
+  }
+  return true
+}
+
+describe('usedValues / isValidPlacement', () => {
+  it('collects row, column, and box values', () => {
+    const grid: Grid = new Array(CELLS).fill(0)
+    grid[0] = 1 // r0c0
+    grid[8] = 2 // r0c8 (same row)
+    grid[9] = 3 // r1c0 (same col)
+    grid[10] = 4 // r1c1 (same box)
+    const used = usedValues(grid, 1) // r0c1
+    expect(used).toEqual(new Set([1, 2, 3, 4]))
+    expect(isValidPlacement(grid, 1, 5)).toBe(true)
+    expect(isValidPlacement(grid, 1, 2)).toBe(false)
+  })
+})
+
+describe('generateSolved', () => {
+  it('produces a fully valid solution', () => {
+    const grid = generateSolved(() => 0.5)
+    expect(grid).toHaveLength(CELLS)
+    expect(isValidSolution(grid)).toBe(true)
+  })
+})
+
+describe('countSolutions', () => {
+  it('finds exactly one solution for a solved grid', () => {
+    expect(countSolutions(generateSolved(() => 0.3), 2)).toBe(1)
+  })
+  it('finds multiple solutions for an empty grid (capped at limit)', () => {
+    expect(countSolutions(new Array(CELLS).fill(0), 2)).toBe(2)
+  })
+})
+
+describe('solve', () => {
+  it('completes a generated puzzle back to its solution', () => {
+    const { puzzle, solution } = generatePuzzle('easy', 'test-seed')
+    expect(solve(puzzle)).toEqual(solution)
+  })
+  it('returns null for a contradictory grid', () => {
+    const grid: Grid = new Array(CELLS).fill(0)
+    grid[0] = 5
+    grid[1] = 5 // two 5s in the same row → unsolvable
+    expect(solve(grid)).toBeNull()
+  })
+})
+
+describe('generatePuzzle', () => {
+  const difficulties: Difficulty[] = ['easy', 'medium', 'hard', 'expert']
+
+  it('is deterministic for a given difficulty + seed', () => {
+    const a = generatePuzzle('medium', 'abc123')
+    const b = generatePuzzle('medium', 'abc123')
+    expect(a.puzzle).toEqual(b.puzzle)
+    expect(a.solution).toEqual(b.solution)
+  })
+
+  it('has a unique solution matching the stored solution', () => {
+    for (const d of difficulties) {
+      const { puzzle, solution } = generatePuzzle(d, `seed-${d}`)
+      expect(countSolutions(puzzle, 2)).toBe(1)
+      expect(solve(puzzle)).toEqual(solution)
+      expect(isValidSolution(solution)).toBe(true)
+    }
+  })
+
+  it('marks givens exactly where the puzzle is non-blank', () => {
+    const { puzzle, given } = generatePuzzle('hard', 'g')
+    puzzle.forEach((v, i) => expect(given[i]).toBe(v !== 0))
+  })
+
+  it('leaves fewer givens for harder difficulties', () => {
+    const easy = generatePuzzle('easy', 's').given.filter(Boolean).length
+    const expert = generatePuzzle('expert', 's').given.filter(Boolean).length
+    expect(easy).toBeGreaterThan(expert)
+  })
+})
+
+describe('findConflicts / isComplete', () => {
+  it('flags both cells of a duplicate in a unit', () => {
+    const grid: Grid = new Array(CELLS).fill(0)
+    grid[0] = 7
+    grid[2] = 7 // same row + same box
+    const conflicts = findConflicts(grid)
+    expect(conflicts.has(0)).toBe(true)
+    expect(conflicts.has(2)).toBe(true)
+  })
+  it('reports completion only for a full, conflict-free grid', () => {
+    const solution = generatePuzzle('easy', 'done').solution
+    expect(isComplete(solution)).toBe(true)
+    const broken = solution.slice()
+    broken[0] = 0
+    expect(isComplete(broken)).toBe(false)
+  })
+})

--- a/src/services/sudoku.spec.ts
+++ b/src/services/sudoku.spec.ts
@@ -13,6 +13,17 @@ import {
   type Grid,
   type Difficulty,
 } from './sudoku'
+import {
+  computeCandidates,
+  digitsOf,
+  findClaiming,
+  findHiddenPair,
+  findHiddenSingle,
+  findHint,
+  findNakedPair,
+  findNakedSingle,
+  findPointing,
+} from './sudokuHints'
 
 const isValidSolution = (grid: Grid): boolean => {
   if (grid.some((v) => v < 1 || v > 9)) return false
@@ -128,5 +139,180 @@ describe('findConflicts / isComplete', () => {
     const broken = solution.slice()
     broken[0] = 0
     expect(isComplete(broken)).toBe(false)
+  })
+})
+
+// --- Strategy-based hints -------------------------------------------------
+
+/** 9-bit candidate mask for the given digits. */
+const bits = (...ds: number[]): number => ds.reduce((m, d) => m | (1 << (d - 1)), 0)
+/** All-cells-filled candidate array (0 = no candidates); set the cells you test. */
+const blankCand = (): number[] => new Array<number>(CELLS).fill(0)
+
+describe('digitsOf / computeCandidates', () => {
+  it('lists the digits set in a mask, ascending', () => {
+    expect(digitsOf(bits(3, 7, 1))).toEqual([1, 3, 7])
+    expect(digitsOf(0)).toEqual([])
+  })
+
+  it('leaves exactly the missing digit for a single blanked cell', () => {
+    const solution = generatePuzzle('medium', 'cand').solution
+    const grid = solution.slice()
+    grid[40] = 0 // blank the centre cell
+    const cand = computeCandidates(grid)
+    expect(digitsOf(cand[40])).toEqual([solution[40]])
+    expect(cand[0]).toBe(0) // filled cells carry no candidates
+  })
+})
+
+describe('findNakedSingle', () => {
+  it('finds a cell with a single candidate and reveals it last', () => {
+    const cand = blankCand()
+    cand[0] = bits(5) // r0c0, box 0 (labelled "box 1" — avoids clashing with digit 5)
+    const hint = findNakedSingle(cand)
+    expect(hint?.technique).toBe('naked-single')
+    expect(hint?.placement).toEqual({ cell: 0, value: 5 })
+    expect(hint?.unit).toEqual({ type: 'box', index: 0 })
+    // Value is only revealed on the final nudge.
+    const levels = hint?.levels ?? []
+    expect(levels.length).toBeGreaterThanOrEqual(3)
+    expect(levels[0]).not.toContain('5')
+    expect(levels[levels.length - 1]).toContain('5')
+  })
+
+  it('returns null when every cell has two or more candidates', () => {
+    const cand = blankCand()
+    cand[0] = bits(1, 2)
+    cand[1] = bits(3, 4)
+    expect(findNakedSingle(cand)).toBeNull()
+  })
+})
+
+describe('findHiddenSingle', () => {
+  it('finds a digit that fits only one cell of a unit', () => {
+    const cand = blankCand()
+    // In row 0, digit 7 is a candidate only in cell 0 (which also allows 8).
+    cand[0] = bits(7, 8)
+    cand[1] = bits(8, 9)
+    cand[2] = bits(8, 9)
+    const hint = findHiddenSingle(cand)
+    expect(hint?.technique).toBe('hidden-single')
+    expect(hint?.placement).toEqual({ cell: 0, value: 7 })
+    expect(hint?.digits).toEqual([7])
+    expect((hint?.levels ?? []).at(-1)).toContain('7')
+  })
+
+  it('ignores naked singles (reported by the easier technique)', () => {
+    const cand = blankCand()
+    cand[0] = bits(7) // sole candidate → naked, not hidden
+    expect(findHiddenSingle(cand)).toBeNull()
+  })
+})
+
+describe('findPointing', () => {
+  it('confines a box candidate to one row and clears the rest of that row', () => {
+    const cand = blankCand()
+    // Box 0: digit 4 only in row 0 (cells 0 and 1)...
+    cand[0] = bits(4, 5)
+    cand[1] = bits(4, 6)
+    // ...but 4 is also a candidate in the same row outside box 0 (cell 3).
+    cand[3] = bits(4, 7)
+    const hint = findPointing(cand)
+    expect(hint?.technique).toBe('pointing')
+    expect(hint?.digits).toEqual([4])
+    expect(hint?.unit).toEqual({ type: 'box', index: 0 })
+    expect(hint?.eliminations).toEqual([{ cell: 3, value: 4 }])
+  })
+
+  it('returns null when the box candidate is not confined to a single line', () => {
+    const cand = blankCand()
+    cand[0] = bits(4) // row 0
+    cand[10] = bits(4) // row 1 → two rows, no pointing
+    expect(findPointing(cand)).toBeNull()
+  })
+})
+
+describe('findClaiming', () => {
+  it('confines a row candidate to one box and clears the rest of that box', () => {
+    const cand = blankCand()
+    // Row 0: digit 3 only in box 0 (cells 0 and 1)...
+    cand[0] = bits(3, 5)
+    cand[1] = bits(3, 6)
+    // ...but 3 is also a candidate elsewhere in box 0 (cell 9, row 1).
+    cand[9] = bits(3, 7)
+    const hint = findClaiming(cand)
+    expect(hint?.technique).toBe('claiming')
+    expect(hint?.digits).toEqual([3])
+    expect(hint?.unit).toEqual({ type: 'row', index: 0 })
+    expect(hint?.eliminations).toEqual([{ cell: 9, value: 3 }])
+  })
+})
+
+describe('findNakedPair', () => {
+  it('finds two cells sharing the same two candidates and clears them elsewhere', () => {
+    const cand = blankCand()
+    cand[0] = bits(1, 2)
+    cand[1] = bits(1, 2) // identical pair with cell 0
+    cand[2] = bits(1, 3) // shares digit 1 → 1 can be removed here
+    const hint = findNakedPair(cand)
+    expect(hint?.technique).toBe('naked-pair')
+    expect(hint?.digits).toEqual([1, 2])
+    expect(hint?.cells).toEqual([0, 1])
+    expect(hint?.eliminations).toEqual([{ cell: 2, value: 1 }])
+  })
+
+  it('returns null when a pair eliminates nothing', () => {
+    const cand = blankCand()
+    cand[0] = bits(1, 2)
+    cand[1] = bits(1, 2)
+    cand[2] = bits(3, 4) // no overlap → no elimination
+    expect(findNakedPair(cand)).toBeNull()
+  })
+})
+
+describe('findHiddenPair', () => {
+  it('finds two digits confined to the same two cells and strips extras', () => {
+    const cand = blankCand()
+    // In row 0, digits 4 and 5 appear only in cells 0 and 1, each with extras.
+    cand[0] = bits(4, 5, 6)
+    cand[1] = bits(4, 5, 7)
+    const hint = findHiddenPair(cand)
+    expect(hint?.technique).toBe('hidden-pair')
+    expect(hint?.digits).toEqual([4, 5])
+    expect(hint?.cells).toEqual([0, 1])
+    expect(hint?.eliminations).toEqual([
+      { cell: 0, value: 6 },
+      { cell: 1, value: 7 },
+    ])
+  })
+})
+
+describe('findHint (integration + priority)', () => {
+  it('returns a naked single for a grid missing one cell', () => {
+    const solution = generatePuzzle('easy', 'hint').solution
+    const grid = solution.slice()
+    grid[20] = 0
+    const hint = findHint(grid)
+    expect(hint?.technique).toBe('naked-single')
+    expect(hint?.placement).toEqual({ cell: 20, value: solution[20] })
+  })
+
+  it('only ever forces correct placements (never a wrong move)', () => {
+    const { puzzle, solution } = generatePuzzle('easy', 'logic-solve')
+    const grid = puzzle.slice()
+    let placed = 0
+    for (let guard = 0; guard < CELLS * 5 && grid.some((v) => v === 0); guard += 1) {
+      const hint = findHint(grid)
+      if (!hint || !hint.placement) break // no move, or an elimination-only step
+      // Every forced single must agree with the unique solution.
+      expect(hint.placement.value).toBe(solution[hint.placement.cell])
+      grid[hint.placement.cell] = hint.placement.value
+      placed += 1
+    }
+    expect(placed).toBeGreaterThan(0)
+  })
+
+  it('returns null for an empty grid (nothing is forced)', () => {
+    expect(findHint(new Array<number>(CELLS).fill(0))).toBeNull()
   })
 })

--- a/src/services/sudoku.ts
+++ b/src/services/sudoku.ts
@@ -1,0 +1,310 @@
+/**
+ * Sudoku engine — puzzle generation, solving, and validation. Pure and
+ * deterministic: pass a seeded RNG to get the same puzzle from a share code.
+ *
+ * A grid is a flat length-81 array of 0..9 (0 = blank). Cell index = row*9 + col.
+ */
+
+import { rngFromSeed } from './seed'
+
+export const N = 9
+export const CELLS = N * N
+
+export type Grid = number[]
+export type Difficulty = 'easy' | 'medium' | 'hard' | 'expert'
+
+/** Target number of givens (clues) per difficulty. Fewer clues = harder. */
+const CLUES: Record<Difficulty, number> = {
+  easy: 40,
+  medium: 33,
+  hard: 28,
+  expert: 24,
+}
+
+const boxStart = (i: number): number => {
+  const r = Math.floor(i / N)
+  const c = i % N
+  return Math.floor(r / 3) * 3 * N + Math.floor(c / 3) * 3
+}
+
+// --- Fast constraint core (bitmasks per row/column/box) ------------------
+// Solving and generation run this hot path thousands of times during
+// uniqueness checks, so candidates are tracked as 9-bit masks and updated
+// incrementally instead of rescanning 27 cells per cell per node.
+
+const FULL = 0x1ff // bits 0..8 set → digits 1..9 available
+const boxOf = (r: number, c: number): number => Math.floor(r / 3) * 3 + Math.floor(c / 3)
+const digitOf = (bit: number): number => 32 - Math.clz32(bit) // 1<<(v-1) → v
+const popcount = (x: number): number => {
+  let n = 0
+  let v = x
+  while (v) {
+    v &= v - 1
+    n += 1
+  }
+  return n
+}
+
+interface Masks {
+  row: Int16Array
+  col: Int16Array
+  box: Int16Array
+}
+
+/** Build per-unit masks, or null if the givens already contain a duplicate. */
+function buildMasks(grid: Grid): Masks | null {
+  const row = new Int16Array(N)
+  const col = new Int16Array(N)
+  const box = new Int16Array(N)
+  for (let i = 0; i < CELLS; i += 1) {
+    const v = grid[i]
+    if (!v) continue
+    const r = (i / N) | 0
+    const c = i % N
+    const b = boxOf(r, c)
+    const bit = 1 << (v - 1)
+    if (row[r] & bit || col[c] & bit || box[b] & bit) return null
+    row[r] |= bit
+    col[c] |= bit
+    box[b] |= bit
+  }
+  return { row, col, box }
+}
+
+/** Index + candidate mask of the empty cell with the fewest candidates. */
+function mostConstrained(grid: Grid, m: Masks): { cell: number; mask: number } {
+  let cell = -1
+  let mask = 0
+  let fewest = N + 1
+  for (let i = 0; i < CELLS; i += 1) {
+    if (grid[i]) continue
+    const r = (i / N) | 0
+    const c = i % N
+    const avail = FULL & ~(m.row[r] | m.col[c] | m.box[boxOf(r, c)])
+    const count = popcount(avail)
+    if (count < fewest) {
+      fewest = count
+      cell = i
+      mask = avail
+      if (count <= 1) break // 0 = dead end, 1 = forced — can't do better
+    }
+  }
+  return { cell, mask }
+}
+
+/** Values already used in the row, column, and box of cell `i`. */
+export function usedValues(grid: Grid, i: number): Set<number> {
+  const r = Math.floor(i / N)
+  const c = i % N
+  const used = new Set<number>()
+  for (let k = 0; k < N; k += 1) {
+    used.add(grid[r * N + k])
+    used.add(grid[k * N + c])
+  }
+  const bs = boxStart(i)
+  for (let dr = 0; dr < 3; dr += 1) {
+    for (let dc = 0; dc < 3; dc += 1) used.add(grid[bs + dr * N + dc])
+  }
+  used.delete(0)
+  return used
+}
+
+/** Whether placing `val` at `i` is legal given the current grid. */
+export function isValidPlacement(grid: Grid, i: number, val: number): boolean {
+  return !usedValues(grid, i).has(val)
+}
+
+const shuffled = (rng: () => number): number[] => {
+  const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[arr[i], arr[j]] = [arr[j], arr[i]]
+  }
+  return arr
+}
+
+/**
+ * Count solutions up to `limit` via backtracking on the most-constrained cell.
+ * Returns as soon as `limit` is reached, so uniqueness checks stay cheap.
+ */
+export function countSolutions(grid: Grid, limit = 2): number {
+  const work = grid.slice()
+  const m = buildMasks(work)
+  if (!m) return 0 // givens already conflict → unsolvable
+  let count = 0
+
+  const recurse = (): void => {
+    const { cell, mask } = mostConstrained(work, m)
+    if (cell === -1) {
+      count += 1 // no empty cells → a complete solution
+      return
+    }
+    if (mask === 0) return // dead end
+    const r = (cell / N) | 0
+    const c = cell % N
+    const b = boxOf(r, c)
+    let bits = mask
+    while (bits) {
+      const bit = bits & -bits
+      bits -= bit
+      work[cell] = digitOf(bit)
+      m.row[r] |= bit
+      m.col[c] |= bit
+      m.box[b] |= bit
+      recurse()
+      m.row[r] &= ~bit
+      m.col[c] &= ~bit
+      m.box[b] &= ~bit
+      work[cell] = 0
+      if (count >= limit) return
+    }
+  }
+
+  recurse()
+  return count
+}
+
+/** Solve a grid; returns a solved copy or null if unsolvable. */
+export function solve(grid: Grid): Grid | null {
+  const work = grid.slice()
+  const m = buildMasks(work)
+  if (!m) return null
+
+  const recurse = (): boolean => {
+    const { cell, mask } = mostConstrained(work, m)
+    if (cell === -1) return true
+    if (mask === 0) return false
+    const r = (cell / N) | 0
+    const c = cell % N
+    const b = boxOf(r, c)
+    let bits = mask
+    while (bits) {
+      const bit = bits & -bits
+      bits -= bit
+      work[cell] = digitOf(bit)
+      m.row[r] |= bit
+      m.col[c] |= bit
+      m.box[b] |= bit
+      if (recurse()) return true
+      m.row[r] &= ~bit
+      m.col[c] &= ~bit
+      m.box[b] &= ~bit
+      work[cell] = 0
+    }
+    return false
+  }
+
+  return recurse() ? work : null
+}
+
+/** Build a full, valid solution grid using randomized backtracking. */
+export function generateSolved(rng: () => number): Grid {
+  const grid: Grid = new Array(CELLS).fill(0)
+  const row = new Int16Array(N)
+  const col = new Int16Array(N)
+  const box = new Int16Array(N)
+
+  const fill = (pos: number): boolean => {
+    if (pos === CELLS) return true
+    const r = (pos / N) | 0
+    const c = pos % N
+    const b = boxOf(r, c)
+    const avail = FULL & ~(row[r] | col[c] | box[b])
+    for (const v of shuffled(rng)) {
+      const bit = 1 << (v - 1)
+      if (!(avail & bit)) continue
+      grid[pos] = v
+      row[r] |= bit
+      col[c] |= bit
+      box[b] |= bit
+      if (fill(pos + 1)) return true
+      grid[pos] = 0
+      row[r] &= ~bit
+      col[c] &= ~bit
+      box[b] &= ~bit
+    }
+    return false
+  }
+
+  fill(0)
+  return grid
+}
+
+export interface Puzzle {
+  puzzle: Grid // the clues shown to the player (0 = blank)
+  solution: Grid // the unique completed grid
+  given: boolean[] // which cells are fixed clues
+  difficulty: Difficulty
+  seed: string
+}
+
+/**
+ * Generate a puzzle with a unique solution by digging cells out of a full grid.
+ * Cells are removed in a seeded random order and only kept removed if the
+ * puzzle still has exactly one solution, so the result is always solvable by
+ * logic (no guessing needed to stay unique).
+ */
+export function generatePuzzle(difficulty: Difficulty, seed: string): Puzzle {
+  const rng = rngFromSeed(`${difficulty}:${seed}`)
+  const solution = generateSolved(rng)
+  const puzzle = solution.slice()
+
+  const order = Array.from({ length: CELLS }, (_, i) => i)
+  for (let i = order.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[order[i], order[j]] = [order[j], order[i]]
+  }
+
+  const targetGivens = CLUES[difficulty]
+  let givens = CELLS
+  for (const idx of order) {
+    if (givens <= targetGivens) break
+    const backup = puzzle[idx]
+    if (backup === 0) continue
+    puzzle[idx] = 0
+    // Keep the dig only if the solution is still unique.
+    if (countSolutions(puzzle, 2) !== 1) {
+      puzzle[idx] = backup
+    } else {
+      givens -= 1
+    }
+  }
+
+  return {
+    puzzle,
+    solution,
+    given: puzzle.map((v) => v !== 0),
+    difficulty,
+    seed,
+  }
+}
+
+/** Cell indices that conflict with another filled cell (share a unit + value). */
+export function findConflicts(grid: Grid): Set<number> {
+  const conflicts = new Set<number>()
+  for (let i = 0; i < CELLS; i += 1) {
+    const v = grid[i]
+    if (v === 0) continue
+    const r = Math.floor(i / N)
+    const c = i % N
+    const bs = boxStart(i)
+    const peers: number[] = []
+    for (let k = 0; k < N; k += 1) {
+      if (k !== c) peers.push(r * N + k)
+      if (k !== r) peers.push(k * N + c)
+    }
+    for (let dr = 0; dr < 3; dr += 1) {
+      for (let dc = 0; dc < 3; dc += 1) {
+        const p = bs + dr * N + dc
+        if (p !== i) peers.push(p)
+      }
+    }
+    if (peers.some((p) => grid[p] === v)) conflicts.add(i)
+  }
+  return conflicts
+}
+
+/** True when every cell is filled and there are no conflicts. */
+export function isComplete(grid: Grid): boolean {
+  return grid.every((v) => v !== 0) && findConflicts(grid).size === 0
+}

--- a/src/services/sudokuHints.ts
+++ b/src/services/sudokuHints.ts
@@ -1,0 +1,375 @@
+/**
+ * Human-strategy Sudoku solver used to power progressive hints.
+ *
+ * Unlike the backtracking solver in ./sudoku (which just brute-forces the
+ * answer), this module finds the *next logically-forced move* the way a person
+ * would — by name — so a hint can nudge the player instead of spoiling the
+ * cell. Techniques, easiest first:
+ *
+ *   1. Naked single    — a cell with only one remaining candidate.
+ *   2. Hidden single    — a digit that fits only one cell of a unit.
+ *   3. Locked candidate — pointing / claiming (candidate confined to a line
+ *                         within a box, or a box within a line → eliminations).
+ *   4. Naked pair       — two cells sharing the same two candidates.
+ *   5. Hidden pair      — two digits confined to the same two cells.
+ *
+ * Candidates are derived purely from the placed digits and the Sudoku
+ * constraints, independent of the player's pencil notes, so a hint reflects the
+ * true logical state of the board.
+ */
+
+import { CELLS, N, type Grid } from './sudoku'
+
+const FULL = 0x1ff // bits 0..8 set → digits 1..9 available
+const boxOf = (r: number, c: number): number => Math.floor(r / 3) * 3 + Math.floor(c / 3)
+const rowOf = (i: number): number => Math.floor(i / N)
+const colOf = (i: number): number => i % N
+
+/** Digits (1..9) present in a 9-bit candidate mask, ascending. */
+export function digitsOf(mask: number): number[] {
+  const out: number[] = []
+  for (let v = 1; v <= N; v += 1) {
+    if (mask & (1 << (v - 1))) out.push(v)
+  }
+  return out
+}
+
+const popcount = (mask: number): number => digitsOf(mask).length
+
+/**
+ * Candidate bitmask for every cell (0 for already-filled cells). A set bit
+ * `1 << (v-1)` means digit `v` is still legal there.
+ */
+export function computeCandidates(grid: Grid): number[] {
+  const row = new Array<number>(N).fill(0)
+  const col = new Array<number>(N).fill(0)
+  const box = new Array<number>(N).fill(0)
+  for (let i = 0; i < CELLS; i += 1) {
+    const v = grid[i]
+    if (!v) continue
+    const bit = 1 << (v - 1)
+    row[rowOf(i)] |= bit
+    col[colOf(i)] |= bit
+    box[boxOf(rowOf(i), colOf(i))] |= bit
+  }
+  const cand = new Array<number>(CELLS).fill(0)
+  for (let i = 0; i < CELLS; i += 1) {
+    if (grid[i]) continue
+    cand[i] = FULL & ~(row[rowOf(i)] | col[colOf(i)] | box[boxOf(rowOf(i), colOf(i))])
+  }
+  return cand
+}
+
+// --- Unit geometry (rows, columns, boxes as lists of cell indices) --------
+
+export type UnitType = 'row' | 'column' | 'box'
+export interface HintUnit {
+  type: UnitType
+  index: number // 0-based
+}
+
+const ROWS: number[][] = []
+const COLS: number[][] = []
+const BOXES: number[][] = []
+for (let u = 0; u < N; u += 1) {
+  const rowCells: number[] = []
+  const colCells: number[] = []
+  const boxCells: number[] = []
+  const br = Math.floor(u / 3) * 3
+  const bc = (u % 3) * 3
+  for (let k = 0; k < N; k += 1) {
+    rowCells.push(u * N + k)
+    colCells.push(k * N + u)
+    boxCells.push((br + Math.floor(k / 3)) * N + (bc + (k % 3)))
+  }
+  ROWS.push(rowCells)
+  COLS.push(colCells)
+  BOXES.push(boxCells)
+}
+
+const unitCells = (unit: HintUnit): number[] =>
+  unit.type === 'row' ? ROWS[unit.index] : unit.type === 'column' ? COLS[unit.index] : BOXES[unit.index]
+
+const cellLabel = (i: number): string => `row ${rowOf(i) + 1}, column ${colOf(i) + 1}`
+const unitLabel = (unit: HintUnit): string => `${unit.type} ${unit.index + 1}`
+
+// --- Structured hint ------------------------------------------------------
+
+export type HintTechnique =
+  | 'naked-single'
+  | 'hidden-single'
+  | 'pointing'
+  | 'claiming'
+  | 'naked-pair'
+  | 'hidden-pair'
+
+export interface Elimination {
+  cell: number
+  value: number
+}
+
+export interface Hint {
+  technique: HintTechnique
+  label: string // human-readable technique name
+  unit: HintUnit
+  digits: number[] // digits the technique is about ("look at the 7s")
+  cells: number[] // defining cells to highlight at the "exact cell" step
+  /** A single forced placement, when the technique yields one (singles). */
+  placement: { cell: number; value: number } | null
+  /** Candidate removals, when the technique is an elimination one. */
+  eliminations: Elimination[]
+  /**
+   * Progressively more specific nudges. Step through them one per hint press;
+   * the FINAL entry reveals the value / elimination. Always at least 1 entry.
+   */
+  levels: string[]
+}
+
+// --- Techniques -----------------------------------------------------------
+
+export function findNakedSingle(cand: number[]): Hint | null {
+  for (let i = 0; i < CELLS; i += 1) {
+    if (cand[i] && popcount(cand[i]) === 1) {
+      const value = digitsOf(cand[i])[0]
+      const unit: HintUnit = { type: 'box', index: boxOf(rowOf(i), colOf(i)) }
+      return {
+        technique: 'naked-single',
+        label: 'Naked single',
+        unit,
+        digits: [value],
+        cells: [i],
+        placement: { cell: i, value },
+        eliminations: [],
+        levels: [
+          `Naked single: one empty cell in ${unitLabel(unit)} has just a single candidate left.`,
+          `Look in ${unitLabel(unit)}, row ${rowOf(i) + 1}.`,
+          `The cell at ${cellLabel(i)} is the one — every other digit is eliminated there.`,
+          `It can only be ${value}.`,
+        ],
+      }
+    }
+  }
+  return null
+}
+
+export function findHiddenSingle(cand: number[]): Hint | null {
+  const units: HintUnit[] = []
+  for (let u = 0; u < N; u += 1) {
+    units.push({ type: 'row', index: u }, { type: 'column', index: u }, { type: 'box', index: u })
+  }
+  for (const unit of units) {
+    const cells = unitCells(unit)
+    for (let v = 1; v <= N; v += 1) {
+      const bit = 1 << (v - 1)
+      const spots = cells.filter((i) => cand[i] & bit)
+      if (spots.length !== 1) continue
+      const cell = spots[0]
+      // Skip when it's really a naked single (reported by the easier technique).
+      if (popcount(cand[cell]) === 1) continue
+      return {
+        technique: 'hidden-single',
+        label: 'Hidden single',
+        unit,
+        digits: [v],
+        cells: [cell],
+        placement: { cell, value: v },
+        eliminations: [],
+        levels: [
+          `Hidden single: in ${unitLabel(unit)}, one digit fits in only a single cell.`,
+          `Look at the ${v}s.`,
+          `In ${unitLabel(unit)}, ${v} can go only in the cell at ${cellLabel(cell)}.`,
+          `Place ${v} there.`,
+        ],
+      }
+    }
+  }
+  return null
+}
+
+/** Pointing: a digit's candidates in a box share one line → clear that line. */
+export function findPointing(cand: number[]): Hint | null {
+  for (let b = 0; b < N; b += 1) {
+    const cells = BOXES[b]
+    for (let v = 1; v <= N; v += 1) {
+      const bit = 1 << (v - 1)
+      const spots = cells.filter((i) => cand[i] & bit)
+      if (spots.length < 2) continue
+      const rows = new Set(spots.map(rowOf))
+      const cols = new Set(spots.map(colOf))
+      let line: HintUnit | null = null
+      if (rows.size === 1) line = { type: 'row', index: rowOf(spots[0]) }
+      else if (cols.size === 1) line = { type: 'column', index: colOf(spots[0]) }
+      if (!line) continue
+      const eliminations = unitCells(line)
+        .filter((i) => !cells.includes(i) && cand[i] & bit)
+        .map((cell) => ({ cell, value: v }))
+      if (!eliminations.length) continue
+      const unit: HintUnit = { type: 'box', index: b }
+      return {
+        technique: 'pointing',
+        label: 'Locked candidate (pointing)',
+        unit,
+        digits: [v],
+        cells: spots,
+        placement: null,
+        eliminations,
+        levels: [
+          `Locked candidate (pointing) in ${unitLabel(unit)}.`,
+          `Look at the ${v}s in ${unitLabel(unit)}.`,
+          `Every spot for ${v} in ${unitLabel(unit)} lies in ${unitLabel(line)}.`,
+          `So ${v} can't appear elsewhere in ${unitLabel(line)} — remove it from ${eliminations.length} cell(s).`,
+        ],
+      }
+    }
+  }
+  return null
+}
+
+/** Claiming: a digit's candidates in a line share one box → clear that box. */
+export function findClaiming(cand: number[]): Hint | null {
+  const lines: HintUnit[] = []
+  for (let u = 0; u < N; u += 1) lines.push({ type: 'row', index: u }, { type: 'column', index: u })
+  for (const line of lines) {
+    const cells = unitCells(line)
+    for (let v = 1; v <= N; v += 1) {
+      const bit = 1 << (v - 1)
+      const spots = cells.filter((i) => cand[i] & bit)
+      if (spots.length < 2) continue
+      const boxes = new Set(spots.map((i) => boxOf(rowOf(i), colOf(i))))
+      if (boxes.size !== 1) continue
+      const b = boxes.values().next().value as number
+      const eliminations = BOXES[b]
+        .filter((i) => !cells.includes(i) && cand[i] & bit)
+        .map((cell) => ({ cell, value: v }))
+      if (!eliminations.length) continue
+      const boxUnit: HintUnit = { type: 'box', index: b }
+      return {
+        technique: 'claiming',
+        label: 'Locked candidate (claiming)',
+        unit: line,
+        digits: [v],
+        cells: spots,
+        placement: null,
+        eliminations,
+        levels: [
+          `Locked candidate (claiming) in ${unitLabel(line)}.`,
+          `Look at the ${v}s in ${unitLabel(line)}.`,
+          `All spots for ${v} in ${unitLabel(line)} fall inside ${unitLabel(boxUnit)}.`,
+          `So ${v} can't appear elsewhere in ${unitLabel(boxUnit)} — remove it from ${eliminations.length} cell(s).`,
+        ],
+      }
+    }
+  }
+  return null
+}
+
+function allUnits(): HintUnit[] {
+  const units: HintUnit[] = []
+  for (let u = 0; u < N; u += 1) {
+    units.push({ type: 'row', index: u }, { type: 'column', index: u }, { type: 'box', index: u })
+  }
+  return units
+}
+
+export function findNakedPair(cand: number[]): Hint | null {
+  for (const unit of allUnits()) {
+    const cells = unitCells(unit)
+    const pairCells = cells.filter((i) => cand[i] && popcount(cand[i]) === 2)
+    for (let a = 0; a < pairCells.length; a += 1) {
+      for (let b = a + 1; b < pairCells.length; b += 1) {
+        if (cand[pairCells[a]] !== cand[pairCells[b]]) continue
+        const mask = cand[pairCells[a]]
+        const pair = [pairCells[a], pairCells[b]]
+        const digits = digitsOf(mask)
+        const eliminations: Elimination[] = []
+        for (const i of cells) {
+          if (pair.includes(i)) continue
+          for (const v of digits) {
+            if (cand[i] & (1 << (v - 1))) eliminations.push({ cell: i, value: v })
+          }
+        }
+        if (!eliminations.length) continue
+        return {
+          technique: 'naked-pair',
+          label: 'Naked pair',
+          unit,
+          digits,
+          cells: pair,
+          placement: null,
+          eliminations,
+          levels: [
+            `Naked pair in ${unitLabel(unit)}.`,
+            `Two cells there share only the candidates ${digits[0]} and ${digits[1]}.`,
+            `Those cells are ${cellLabel(pair[0])} and ${cellLabel(pair[1])} — locking up ${digits.join(' & ')}.`,
+            `So remove ${digits.join(' & ')} from the other ${eliminations.length} candidate(s) in ${unitLabel(unit)}.`,
+          ],
+        }
+      }
+    }
+  }
+  return null
+}
+
+export function findHiddenPair(cand: number[]): Hint | null {
+  for (const unit of allUnits()) {
+    const cells = unitCells(unit)
+    // For each digit, which cells of this unit can hold it.
+    const spotsFor: Record<number, number[]> = {}
+    for (let v = 1; v <= N; v += 1) {
+      spotsFor[v] = cells.filter((i) => cand[i] & (1 << (v - 1)))
+    }
+    for (let a = 1; a <= N; a += 1) {
+      if (spotsFor[a].length !== 2) continue
+      for (let b = a + 1; b <= N; b += 1) {
+        if (spotsFor[b].length !== 2) continue
+        const [a0, a1] = spotsFor[a]
+        const [b0, b1] = spotsFor[b]
+        if (a0 !== b0 || a1 !== b1) continue // must be the same two cells
+        const pair = [a0, a1]
+        const pairMask = (1 << (a - 1)) | (1 << (b - 1))
+        const eliminations: Elimination[] = []
+        for (const i of pair) {
+          for (const v of digitsOf(cand[i] & ~pairMask)) eliminations.push({ cell: i, value: v })
+        }
+        if (!eliminations.length) continue
+        return {
+          technique: 'hidden-pair',
+          label: 'Hidden pair',
+          unit,
+          digits: [a, b],
+          cells: pair,
+          placement: null,
+          eliminations,
+          levels: [
+            `Hidden pair in ${unitLabel(unit)}.`,
+            `Look at the ${a}s and ${b}s.`,
+            `Only two cells in ${unitLabel(unit)} can hold ${a} or ${b}: ${cellLabel(pair[0])} and ${cellLabel(pair[1])}.`,
+            `So those cells are just ${a}/${b} — remove the other ${eliminations.length} candidate(s) from them.`,
+          ],
+        }
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Find the easiest logically-forced hint for the current board, or null when no
+ * supported technique applies (e.g. the position needs guessing or is solved).
+ */
+export function findHint(grid: Grid): Hint | null {
+  const cand = computeCandidates(grid)
+  const finders = [
+    findNakedSingle,
+    findHiddenSingle,
+    findPointing,
+    findClaiming,
+    findNakedPair,
+    findHiddenPair,
+  ]
+  for (const finder of finders) {
+    const hint = finder(cand)
+    if (hint) return hint
+  }
+  return null
+}

--- a/src/services/tango.spec.ts
+++ b/src/services/tango.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CELLS,
+  EMPTY,
+  HALF,
+  MOON,
+  SIZE,
+  SUN,
+  countSolutions,
+  findConflicts,
+  generateSolved,
+  generateTango,
+  isSolved,
+  solve,
+  type Constraint,
+  type Grid,
+} from './tango'
+
+const isValidFull = (grid: Grid, constraints: Constraint[]): boolean => {
+  if (grid.some((v) => v !== SUN && v !== MOON)) return false
+  for (let r = 0; r < SIZE; r += 1) {
+    let s = 0
+    for (let c = 0; c < SIZE; c += 1) if (grid[r * SIZE + c] === SUN) s += 1
+    if (s !== HALF) return false
+  }
+  for (let c = 0; c < SIZE; c += 1) {
+    let s = 0
+    for (let r = 0; r < SIZE; r += 1) if (grid[r * SIZE + c] === SUN) s += 1
+    if (s !== HALF) return false
+  }
+  return findConflicts(grid, constraints).size === 0
+}
+
+describe('generateSolved', () => {
+  it('builds a balanced, triple-free board', () => {
+    const grid = generateSolved(() => 0.5)
+    expect(grid).toHaveLength(CELLS)
+    expect(isValidFull(grid, [])).toBe(true)
+  })
+  it('varies with the RNG', () => {
+    const a = generateSolved(() => 0.2)
+    const b = generateSolved(() => 0.8)
+    expect(a).not.toEqual(b)
+  })
+})
+
+describe('findConflicts', () => {
+  it('flags three-in-a-row', () => {
+    const grid: Grid = new Array(CELLS).fill(EMPTY)
+    grid[0] = SUN
+    grid[1] = SUN
+    grid[2] = SUN
+    const conflicts = findConflicts(grid, [])
+    expect(conflicts.has(0)).toBe(true)
+    expect(conflicts.has(2)).toBe(true)
+  })
+  it('flags too many of one symbol in a row', () => {
+    const grid: Grid = new Array(CELLS).fill(EMPTY)
+    // 4 moons in row 0 (> HALF) arranged to avoid a three-in-a-row.
+    grid[0] = MOON
+    grid[1] = MOON
+    grid[2] = SUN
+    grid[3] = MOON
+    grid[4] = MOON
+    expect(findConflicts(grid, []).size).toBeGreaterThan(0)
+  })
+  it('flags a violated equality constraint', () => {
+    const grid: Grid = new Array(CELLS).fill(EMPTY)
+    grid[0] = SUN
+    grid[1] = MOON
+    const constraints: Constraint[] = [{ a: 0, b: 1, kind: 'eq' }]
+    expect(findConflicts(grid, constraints).has(0)).toBe(true)
+  })
+  it('accepts a satisfied opposite constraint', () => {
+    const grid: Grid = new Array(CELLS).fill(EMPTY)
+    grid[0] = SUN
+    grid[1] = MOON
+    const constraints: Constraint[] = [{ a: 0, b: 1, kind: 'opp' }]
+    expect(findConflicts(grid, constraints).size).toBe(0)
+  })
+})
+
+describe('generateTango', () => {
+  it('is deterministic for a seed', () => {
+    const a = generateTango('seed-x')
+    const b = generateTango('seed-x')
+    expect(a.given).toEqual(b.given)
+    expect(a.solution).toEqual(b.solution)
+    expect(a.constraints).toEqual(b.constraints)
+  })
+
+  it('produces a unique solution matching the stored solution', () => {
+    for (const seed of ['a', 'b', 'c', 'd']) {
+      const { given, solution, constraints } = generateTango(seed)
+      expect(isValidFull(solution, constraints)).toBe(true)
+      expect(countSolutions(given, constraints, 2)).toBe(1)
+      expect(solve(given, constraints)).toEqual(solution)
+    }
+  })
+
+  it('constraints are consistent with the solution', () => {
+    const { solution, constraints } = generateTango('consistent')
+    for (const { a, b, kind } of constraints) {
+      if (kind === 'eq') expect(solution[a]).toBe(solution[b])
+      else expect(solution[a]).not.toBe(solution[b])
+    }
+  })
+
+  it('leaves at least one blank (clues are trimmed)', () => {
+    const { given } = generateTango('trim')
+    expect(given.some((v) => v === EMPTY)).toBe(true)
+  })
+})
+
+describe('isSolved', () => {
+  it('is true only for a full, valid grid', () => {
+    const { solution, constraints } = generateTango('done')
+    expect(isSolved(solution, constraints)).toBe(true)
+    const partial = solution.slice()
+    partial[0] = EMPTY
+    expect(isSolved(partial, constraints)).toBe(false)
+  })
+})

--- a/src/services/tango.spec.ts
+++ b/src/services/tango.spec.ts
@@ -112,6 +112,17 @@ describe('generateTango', () => {
   })
 })
 
+describe('solver rejects inconsistent givens', () => {
+  it('returns 0 / null when givens already break a rule', () => {
+    const given: Grid = new Array(CELLS).fill(EMPTY)
+    given[0] = SUN
+    given[1] = SUN
+    given[2] = SUN // three-in-a-row among givens
+    expect(countSolutions(given, [], 2)).toBe(0)
+    expect(solve(given, [])).toBeNull()
+  })
+})
+
 describe('isSolved', () => {
   it('is true only for a full, valid grid', () => {
     const { solution, constraints } = generateTango('done')

--- a/src/services/tango.spec.ts
+++ b/src/services/tango.spec.ts
@@ -15,6 +15,9 @@ import {
   type Constraint,
   type Grid,
 } from './tango'
+import { findHint, symbolName } from './tangoHints'
+
+const emptyGrid = (): Grid => new Array(CELLS).fill(EMPTY)
 
 const isValidFull = (grid: Grid, constraints: Constraint[]): boolean => {
   if (grid.some((v) => v !== SUN && v !== MOON)) return false
@@ -130,5 +133,123 @@ describe('isSolved', () => {
     const partial = solution.slice()
     partial[0] = EMPTY
     expect(isSolved(partial, constraints)).toBe(false)
+  })
+})
+
+describe('findHint — no-three-in-a-row rule', () => {
+  it('forces the cell sandwiched between two equal symbols', () => {
+    // row 0: SUN _ SUN  → the middle must be a MOON
+    const grid = emptyGrid()
+    grid[0] = SUN
+    grid[2] = SUN
+    const hint = findHint(grid, [])
+    expect(hint).not.toBeNull()
+    expect(hint?.rule).toBe('triple')
+    expect(hint?.cell).toBe(1)
+    expect(hint?.value).toBe(MOON)
+    expect(hint?.because).toEqual(expect.arrayContaining([0, 2]))
+  })
+
+  it('forces the cell beside an existing equal pair', () => {
+    // row 0: SUN SUN _  → the next cell must be a MOON
+    const grid = emptyGrid()
+    grid[0] = SUN
+    grid[1] = SUN
+    const hint = findHint(grid, [])
+    expect(hint?.rule).toBe('triple')
+    expect(hint?.cell).toBe(2)
+    expect(hint?.value).toBe(MOON)
+  })
+
+  it('works vertically as well', () => {
+    // column 0: MOON MOON _ down the left edge → cell below must be a SUN
+    const grid = emptyGrid()
+    grid[0] = MOON
+    grid[SIZE] = MOON
+    const hint = findHint(grid, [])
+    expect(hint?.rule).toBe('triple')
+    expect(hint?.cell).toBe(2 * SIZE)
+    expect(hint?.value).toBe(SUN)
+  })
+})
+
+describe('findHint — balance rule', () => {
+  it('fills the rest of a line once one symbol hits its max', () => {
+    // row 0 gets its three Suns (no triple); the last empty cell must be a Moon.
+    const grid = emptyGrid()
+    grid[0] = SUN
+    grid[1] = MOON
+    grid[2] = SUN
+    grid[3] = MOON
+    grid[4] = SUN
+    // cell 5 is the only empty in the row
+    const hint = findHint(grid, [])
+    expect(hint?.rule).toBe('balance')
+    expect(hint?.cell).toBe(5)
+    expect(hint?.value).toBe(MOON)
+    expect(hint?.because).toEqual(expect.arrayContaining([0, 2, 4]))
+  })
+})
+
+describe('findHint — link (= / ×) rule', () => {
+  it('copies a value across an equality badge', () => {
+    const grid = emptyGrid()
+    grid[0] = SUN
+    const hint = findHint(grid, [{ a: 0, b: 1, kind: 'eq' }])
+    expect(hint?.rule).toBe('link')
+    expect(hint?.cell).toBe(1)
+    expect(hint?.value).toBe(SUN)
+    expect(hint?.because).toEqual([0])
+  })
+
+  it('flips a value across an opposite badge', () => {
+    const grid = emptyGrid()
+    grid[0] = SUN
+    const hint = findHint(grid, [{ a: 0, b: 1, kind: 'opp' }])
+    expect(hint?.rule).toBe('link')
+    expect(hint?.cell).toBe(1)
+    expect(hint?.value).toBe(MOON)
+  })
+})
+
+describe('findHint — integration', () => {
+  it('returns null when no single rule settles a cell', () => {
+    expect(findHint(emptyGrid(), [])).toBeNull()
+  })
+
+  it('only ever suggests moves that agree with the real solution', () => {
+    let applied = 0
+    // Walk each puzzle by repeatedly applying the deduced hint. Every suggestion
+    // must match the unique solution, and the engine must never contradict it.
+    for (const seed of ['a', 'b', 'c', 'd', 'hint-seed']) {
+      const { given, solution, constraints } = generateTango(seed)
+      const grid = given.slice()
+      for (let step = 0; step < CELLS; step += 1) {
+        const hint = findHint(grid, constraints)
+        if (!hint) break
+        expect(grid[hint.cell]).toBe(EMPTY) // never re-suggests a filled cell
+        expect(solution[hint.cell]).toBe(hint.value)
+        grid[hint.cell] = hint.value
+        applied += 1
+      }
+    }
+    // The deduction engine fires on real puzzles (not merely a no-op).
+    expect(applied).toBeGreaterThan(0)
+  })
+
+  it('solves a solution missing a single forced cell', () => {
+    const { solution, constraints } = generateTango('almost')
+    const grid = solution.slice()
+    grid[10] = EMPTY
+    const hint = findHint(grid, constraints)
+    expect(hint?.cell).toBe(10)
+    expect(hint?.value).toBe(solution[10])
+  })
+})
+
+describe('symbolName', () => {
+  it('names the symbols', () => {
+    expect(symbolName(SUN)).toBe('Sun')
+    expect(symbolName(MOON)).toBe('Moon')
   })
 })

--- a/src/services/tango.ts
+++ b/src/services/tango.ts
@@ -1,0 +1,304 @@
+/**
+ * Tango engine — a 6×6 binary-logic puzzle (LinkedIn-style). Each cell is a Sun
+ * (0) or Moon (1). A full board is valid when:
+ *   - every row and every column has exactly three of each symbol,
+ *   - no three of the same symbol are adjacent (horizontally or vertically),
+ *   - all "=" (equal) and "×" (opposite) edge constraints between neighbors hold.
+ *
+ * Puzzles are generated from a seed by building a valid full board, adding a
+ * minimal set of clues + constraints, and verifying a unique solution.
+ */
+
+import { rngFromSeed } from './seed'
+
+export const SIZE = 6
+export const HALF = SIZE / 2
+export const CELLS = SIZE * SIZE
+
+export const SUN = 0
+export const MOON = 1
+export const EMPTY = -1
+
+export type Cell = -1 | 0 | 1
+export type Grid = Cell[]
+
+/** A constraint between two orthogonally adjacent cells. */
+export interface Constraint {
+  a: number // cell index
+  b: number // neighbor index (b === a+1 for horizontal, a+SIZE for vertical)
+  kind: 'eq' | 'opp'
+}
+
+export interface Puzzle {
+  given: Grid // clues shown (-1 = blank)
+  solution: Grid // the unique full solution (0/1)
+  constraints: Constraint[]
+  seed: string
+}
+
+const rc = (i: number): [number, number] => [Math.floor(i / SIZE), i % SIZE]
+
+/** Values already three-of-a-kind or three-in-a-row would break — used by the solver. */
+function violates(grid: Grid, i: number, val: Cell, constraints: Map<string, 'eq' | 'opp'>): boolean {
+  const [r, c] = rc(i)
+
+  // Count in row/column must not exceed HALF for either symbol.
+  let rowCount = 0
+  let colCount = 0
+  let rowFilled = 0
+  let colFilled = 0
+  for (let k = 0; k < SIZE; k += 1) {
+    const rv = k === c ? val : grid[r * SIZE + k]
+    const cv = k === r ? val : grid[k * SIZE + c]
+    if (rv !== EMPTY) {
+      rowFilled += 1
+      if (rv === val) rowCount += 1
+    }
+    if (cv !== EMPTY) {
+      colFilled += 1
+      if (cv === val) colCount += 1
+    }
+  }
+  if (rowCount > HALF || colCount > HALF) return true
+  // If the line is full it must be balanced (exactly HALF each).
+  if (rowFilled === SIZE && rowCount !== HALF) return true
+  if (colFilled === SIZE && colCount !== HALF) return true
+
+  // No three consecutive equal symbols, horizontally or vertically.
+  const at = (rr: number, cc: number): Cell => {
+    if (rr < 0 || rr >= SIZE || cc < 0 || cc >= SIZE) return EMPTY
+    if (rr === r && cc === c) return val
+    return grid[rr * SIZE + cc]
+  }
+  const triples: Array<[number, number][]> = [
+    [[r, c - 2], [r, c - 1], [r, c]],
+    [[r, c - 1], [r, c], [r, c + 1]],
+    [[r, c], [r, c + 1], [r, c + 2]],
+    [[r - 2, c], [r - 1, c], [r, c]],
+    [[r - 1, c], [r, c], [r + 1, c]],
+    [[r, c], [r + 1, c], [r + 2, c]],
+  ]
+  for (const t of triples) {
+    if (t.every(([rr, cc]) => at(rr, cc) === val)) return true
+  }
+
+  // Edge constraints touching this cell.
+  const neighbors = [i - 1, i + 1, i - SIZE, i + SIZE]
+  for (const n of neighbors) {
+    if (n < 0 || n >= CELLS) continue
+    // Skip horizontal wrap-around.
+    if ((n === i - 1 || n === i + 1) && Math.floor(n / SIZE) !== r) continue
+    const key = edgeKey(i, n)
+    const kind = constraints.get(key)
+    if (kind === undefined) continue
+    const nv = grid[n]
+    if (nv === EMPTY) continue
+    if (kind === 'eq' && nv !== val) return true
+    if (kind === 'opp' && nv === val) return true
+  }
+  return false
+}
+
+const edgeKey = (a: number, b: number): string => (a < b ? `${a}-${b}` : `${b}-${a}`)
+
+const constraintMap = (constraints: Constraint[]): Map<string, 'eq' | 'opp'> => {
+  const m = new Map<string, 'eq' | 'opp'>()
+  for (const c of constraints) m.set(edgeKey(c.a, c.b), c.kind)
+  return m
+}
+
+/**
+ * Count solutions (up to `limit`) consistent with the givens and constraints.
+ * Fills cells in order, pruning with `violates`.
+ */
+export function countSolutions(given: Grid, constraints: Constraint[], limit = 2): number {
+  const map = constraintMap(constraints)
+  const work = given.slice()
+  let count = 0
+
+  const recurse = (pos: number): void => {
+    if (count >= limit) return
+    if (pos === CELLS) {
+      count += 1
+      return
+    }
+    if (work[pos] !== EMPTY) {
+      recurse(pos + 1)
+      return
+    }
+    for (const val of [SUN, MOON] as Cell[]) {
+      if (!violates(work, pos, val, map)) {
+        work[pos] = val
+        recurse(pos + 1)
+        work[pos] = EMPTY
+        if (count >= limit) return
+      }
+    }
+  }
+
+  recurse(0)
+  return count
+}
+
+/** Solve givens+constraints; returns the completed grid or null. */
+export function solve(given: Grid, constraints: Constraint[]): Grid | null {
+  const map = constraintMap(constraints)
+  const work = given.slice()
+  let result: Grid | null = null
+
+  const recurse = (pos: number): boolean => {
+    if (pos === CELLS) {
+      result = work.slice()
+      return true
+    }
+    if (work[pos] !== EMPTY) return recurse(pos + 1)
+    for (const val of [SUN, MOON] as Cell[]) {
+      if (!violates(work, pos, val, map)) {
+        work[pos] = val
+        if (recurse(pos + 1)) return true
+        work[pos] = EMPTY
+      }
+    }
+    return false
+  }
+
+  recurse(0)
+  return result
+}
+
+/** Build a random valid full board using backtracking with a shuffled choice order. */
+export function generateSolved(rng: () => number): Grid {
+  const empty: Grid = new Array(CELLS).fill(EMPTY)
+  const noConstraints = new Map<string, 'eq' | 'opp'>()
+  const work = empty.slice()
+
+  const recurse = (pos: number): boolean => {
+    if (pos === CELLS) return true
+    const order: Cell[] = rng() < 0.5 ? [SUN, MOON] : [MOON, SUN]
+    for (const val of order) {
+      if (!violates(work, pos, val, noConstraints)) {
+        work[pos] = val
+        if (recurse(pos + 1)) return true
+        work[pos] = EMPTY
+      }
+    }
+    return false
+  }
+
+  recurse(0)
+  return work
+}
+
+/** All orthogonal adjacent edges of the board, as [a, b] with a < b. */
+function allEdges(): Array<[number, number]> {
+  const edges: Array<[number, number]> = []
+  for (let i = 0; i < CELLS; i += 1) {
+    const [r, c] = rc(i)
+    if (c < SIZE - 1) edges.push([i, i + 1])
+    if (r < SIZE - 1) edges.push([i, i + SIZE])
+  }
+  return edges
+}
+
+/**
+ * Generate a uniquely-solvable puzzle. Strategy: from a full solution, seed a
+ * handful of edge constraints (matching the solution), then add just enough cell
+ * clues so the solution is unique, then trim clues that aren't needed.
+ */
+export function generateTango(seed: string): Puzzle {
+  const rng = rngFromSeed(`tango:${seed}`)
+  const solution = generateSolved(rng)
+
+  // Pick a random subset of edges as constraints, typed to match the solution.
+  const edges = allEdges()
+  for (let i = edges.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[edges[i], edges[j]] = [edges[j], edges[i]]
+  }
+  const constraints: Constraint[] = edges.slice(0, 8).map(([a, b]) => ({
+    a,
+    b,
+    kind: solution[a] === solution[b] ? 'eq' : 'opp',
+  }))
+
+  // Add clues (in random order) until the solution is unique.
+  const order = Array.from({ length: CELLS }, (_, i) => i)
+  for (let i = order.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[order[i], order[j]] = [order[j], order[i]]
+  }
+
+  const given: Grid = new Array(CELLS).fill(EMPTY)
+  for (const idx of order) {
+    if (countSolutions(given, constraints, 2) === 1) break
+    given[idx] = solution[idx]
+  }
+
+  // Trim clues that are redundant (removing them keeps the solution unique).
+  for (const idx of order) {
+    if (given[idx] === EMPTY) continue
+    const backup = given[idx]
+    given[idx] = EMPTY
+    if (countSolutions(given, constraints, 2) !== 1) given[idx] = backup
+  }
+
+  return { given, solution, constraints, seed }
+}
+
+/** Cells that break a rule given the current (possibly partial) grid. */
+export function findConflicts(grid: Grid, constraints: Constraint[]): Set<number> {
+  const conflicts = new Set<number>()
+
+  // Three-in-a-row (any three consecutive equal, non-empty).
+  for (let r = 0; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      const i = r * SIZE + c
+      const v = grid[i]
+      if (v === EMPTY) continue
+      if (c <= SIZE - 3 && grid[i + 1] === v && grid[i + 2] === v) {
+        conflicts.add(i).add(i + 1).add(i + 2)
+      }
+      if (r <= SIZE - 3 && grid[i + SIZE] === v && grid[i + 2 * SIZE] === v) {
+        conflicts.add(i).add(i + SIZE).add(i + 2 * SIZE)
+      }
+    }
+  }
+
+  // Too many of one symbol in a full-ish line.
+  for (let r = 0; r < SIZE; r += 1) {
+    const suns: number[] = []
+    const moons: number[] = []
+    for (let c = 0; c < SIZE; c += 1) {
+      const i = r * SIZE + c
+      if (grid[i] === SUN) suns.push(i)
+      else if (grid[i] === MOON) moons.push(i)
+    }
+    if (suns.length > HALF) suns.forEach((i) => conflicts.add(i))
+    if (moons.length > HALF) moons.forEach((i) => conflicts.add(i))
+  }
+  for (let c = 0; c < SIZE; c += 1) {
+    const suns: number[] = []
+    const moons: number[] = []
+    for (let r = 0; r < SIZE; r += 1) {
+      const i = r * SIZE + c
+      if (grid[i] === SUN) suns.push(i)
+      else if (grid[i] === MOON) moons.push(i)
+    }
+    if (suns.length > HALF) suns.forEach((i) => conflicts.add(i))
+    if (moons.length > HALF) moons.forEach((i) => conflicts.add(i))
+  }
+
+  // Violated edge constraints (both cells filled).
+  for (const { a, b, kind } of constraints) {
+    if (grid[a] === EMPTY || grid[b] === EMPTY) continue
+    if (kind === 'eq' && grid[a] !== grid[b]) conflicts.add(a).add(b)
+    if (kind === 'opp' && grid[a] === grid[b]) conflicts.add(a).add(b)
+  }
+
+  return conflicts
+}
+
+/** True when the grid is full, balanced, and rule-compliant. */
+export function isSolved(grid: Grid, constraints: Constraint[]): boolean {
+  return grid.every((v) => v !== EMPTY) && findConflicts(grid, constraints).size === 0
+}

--- a/src/services/tango.ts
+++ b/src/services/tango.ts
@@ -112,6 +112,7 @@ const constraintMap = (constraints: Constraint[]): Map<string, 'eq' | 'opp'> => 
  * Fills cells in order, pruning with `violates`.
  */
 export function countSolutions(given: Grid, constraints: Constraint[], limit = 2): number {
+  if (findConflicts(given, constraints).size > 0) return 0 // givens already break a rule
   const map = constraintMap(constraints)
   const work = given.slice()
   let count = 0
@@ -142,6 +143,7 @@ export function countSolutions(given: Grid, constraints: Constraint[], limit = 2
 
 /** Solve givens+constraints; returns the completed grid or null. */
 export function solve(given: Grid, constraints: Constraint[]): Grid | null {
+  if (findConflicts(given, constraints).size > 0) return null // givens already break a rule
   const map = constraintMap(constraints)
   const work = given.slice()
   let result: Grid | null = null

--- a/src/services/tangoHints.ts
+++ b/src/services/tangoHints.ts
@@ -1,0 +1,188 @@
+/**
+ * Tango hint engine — pure, deterministic deduction. Given the current (partial)
+ * grid and its edge constraints, it finds the next cell whose value is *forced*
+ * by a single logical rule, and explains why. No guessing or backtracking: only
+ * the three techniques a human uses.
+ *
+ *   - triple  : the no-three-in-a-row rule. Two equal neighbours force the
+ *               opposite on the cell beside them, and a cell sandwiched between
+ *               two equals is forced to the opposite.
+ *   - balance : once a row or column already holds its three of one symbol, every
+ *               remaining empty cell in that line must be the other symbol.
+ *   - link    : an "=" (equal) or "×" (opposite) badge propagates a known cell's
+ *               value to its blank neighbour.
+ *
+ * The view reveals a hint progressively (region → cell → value), so a `Hint`
+ * carries the target cell, the forced value, the supporting evidence cells, the
+ * region to spotlight first, and a plain-language reason.
+ */
+
+import { EMPTY, HALF, MOON, SIZE, SUN, type Cell, type Constraint, type Grid } from './tango'
+
+export type HintRule = 'triple' | 'balance' | 'link'
+
+export interface Hint {
+  /** The empty cell whose value is logically forced. */
+  cell: number
+  /** The value it must take (SUN or MOON). */
+  value: Cell
+  /** Which deduction rule forced it. */
+  rule: HintRule
+  /** The cells that provide the evidence (highlighted with the exact cell). */
+  because: number[]
+  /** Cells to spotlight first, before the exact cell is revealed. */
+  region: number[]
+  /** Plain-language explanation of the rule + region (no cell/value spoiler). */
+  reason: string
+}
+
+const rc = (i: number): [number, number] => [Math.floor(i / SIZE), i % SIZE]
+const idx = (r: number, c: number): number => r * SIZE + c
+const opposite = (v: Cell): Cell => (v === SUN ? MOON : SUN)
+const symbolName = (v: Cell): string => (v === SUN ? 'Sun' : 'Moon')
+
+const rowLine = (r: number): number[] => Array.from({ length: SIZE }, (_, k) => idx(r, k))
+const colLine = (c: number): number[] => Array.from({ length: SIZE }, (_, k) => idx(k, c))
+
+/**
+ * No-three-in-a-row deduction for a single empty cell. If two of its in-line
+ * partners are equal and filled — sitting before it, after it, or straddling it —
+ * then placing that symbol here would make three in a row, so the opposite is
+ * forced.
+ */
+function tripleHint(grid: Grid, i: number): Hint | null {
+  const [r, c] = rc(i)
+
+  const check = (
+    pairs: Array<[number, number]>,
+    line: number[],
+    axis: string,
+    which: number,
+  ): Hint | null => {
+    for (const [p, q] of pairs) {
+      if (grid[p] !== EMPTY && grid[p] === grid[q]) {
+        const value = opposite(grid[p])
+        return {
+          cell: i,
+          value,
+          rule: 'triple',
+          because: [p, q],
+          region: line,
+          reason: `No three in a row: ${axis} ${which} already has two ${symbolName(grid[p])}s in a line, so the next cell can't be a third.`,
+        }
+      }
+    }
+    return null
+  }
+
+  const hpairs: Array<[number, number]> = []
+  if (c >= 2) hpairs.push([idx(r, c - 2), idx(r, c - 1)]) // pair sits before i
+  if (c >= 1 && c <= SIZE - 2) hpairs.push([idx(r, c - 1), idx(r, c + 1)]) // i is sandwiched
+  if (c <= SIZE - 3) hpairs.push([idx(r, c + 1), idx(r, c + 2)]) // pair sits after i
+  const h = check(hpairs, rowLine(r), 'row', r + 1)
+  if (h) return h
+
+  const vpairs: Array<[number, number]> = []
+  if (r >= 2) vpairs.push([idx(r - 2, c), idx(r - 1, c)])
+  if (r >= 1 && r <= SIZE - 2) vpairs.push([idx(r - 1, c), idx(r + 1, c)])
+  if (r <= SIZE - 3) vpairs.push([idx(r + 1, c), idx(r + 2, c)])
+  return check(vpairs, colLine(c), 'column', c + 1)
+}
+
+/**
+ * Balance deduction for a single empty cell: if its row or column already holds
+ * HALF of one symbol, the cell must be the other symbol.
+ */
+function balanceHint(grid: Grid, i: number): Hint | null {
+  const [r, c] = rc(i)
+
+  const scan = (line: number[], axis: string, which: number): Hint | null => {
+    const suns = line.filter((k) => grid[k] === SUN)
+    const moons = line.filter((k) => grid[k] === MOON)
+    if (suns.length === HALF) {
+      return {
+        cell: i,
+        value: MOON,
+        rule: 'balance',
+        because: suns,
+        region: line,
+        reason: `Balance: ${axis} ${which} already has all ${HALF} of its Suns, so its empty cells must be Moons.`,
+      }
+    }
+    if (moons.length === HALF) {
+      return {
+        cell: i,
+        value: SUN,
+        rule: 'balance',
+        because: moons,
+        region: line,
+        reason: `Balance: ${axis} ${which} already has all ${HALF} of its Moons, so its empty cells must be Suns.`,
+      }
+    }
+    return null
+  }
+
+  return scan(rowLine(r), 'row', r + 1) ?? scan(colLine(c), 'column', c + 1)
+}
+
+/**
+ * Link deduction: for a constraint touching this empty cell whose other end is
+ * filled, "=" copies that value and "×" flips it.
+ */
+function linkHint(
+  grid: Grid,
+  i: number,
+  byCell: Map<number, Array<{ other: number; kind: 'eq' | 'opp' }>>,
+): Hint | null {
+  for (const { other, kind } of byCell.get(i) ?? []) {
+    if (grid[other] === EMPTY) continue
+    const known = grid[other] as Cell
+    const value = kind === 'eq' ? known : opposite(known)
+    return {
+      cell: i,
+      value,
+      rule: 'link',
+      because: [other],
+      region: [other],
+      reason:
+        kind === 'eq'
+          ? 'Equal (=) badge: this cell must match its highlighted neighbour.'
+          : 'Opposite (×) badge: this cell must differ from its highlighted neighbour.',
+    }
+  }
+  return null
+}
+
+/** Index constraints by each endpoint cell for quick lookup. */
+function indexConstraints(
+  constraints: Constraint[],
+): Map<number, Array<{ other: number; kind: 'eq' | 'opp' }>> {
+  const m = new Map<number, Array<{ other: number; kind: 'eq' | 'opp' }>>()
+  const add = (cell: number, other: number, kind: 'eq' | 'opp') => {
+    const list = m.get(cell) ?? []
+    list.push({ other, kind })
+    m.set(cell, list)
+  }
+  for (const { a, b, kind } of constraints) {
+    add(a, b, kind)
+    add(b, a, kind)
+  }
+  return m
+}
+
+/**
+ * Find the next logically-forced cell in the current grid, or null if no single
+ * rule settles a cell outright. Empty cells are scanned in reading order and, for
+ * each, the triple → link → balance rules are tried; the first hit is returned.
+ */
+export function findHint(grid: Grid, constraints: Constraint[]): Hint | null {
+  const byCell = indexConstraints(constraints)
+  for (let i = 0; i < grid.length; i += 1) {
+    if (grid[i] !== EMPTY) continue
+    const hit = tripleHint(grid, i) ?? linkHint(grid, i, byCell) ?? balanceHint(grid, i)
+    if (hit) return hit
+  }
+  return null
+}
+
+export { symbolName }

--- a/src/services/tetris.spec.ts
+++ b/src/services/tetris.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import {
+  COLS,
+  ROWS,
+  clearLines,
+  collides,
+  createBag,
+  dropRow,
+  emptyBoard,
+  gravityMs,
+  lineScore,
+  matrixFor,
+  merge,
+  pieceCells,
+  rotate,
+  spawnPiece,
+  type Board,
+} from './tetris'
+
+describe('matrixFor', () => {
+  it('rotates 4 times back to the original', () => {
+    expect(matrixFor('T', 4)).toEqual(matrixFor('T', 0))
+    expect(matrixFor('T', -1)).toEqual(matrixFor('T', 3))
+  })
+  it('rotates the T piece clockwise', () => {
+    // spawn T: top-middle filled; after one CW turn the stem points right.
+    expect(matrixFor('T', 1)).toEqual([
+      [0, 1, 0],
+      [0, 1, 1],
+      [0, 1, 0],
+    ])
+  })
+})
+
+describe('spawnPiece', () => {
+  it('places the first filled row at y = 0 and centers horizontally', () => {
+    const t = spawnPiece('T')
+    expect(t.y).toBe(0)
+    expect(pieceCells(t).some((c) => c.y === 0)).toBe(true)
+    const i = spawnPiece('I')
+    expect(i.y).toBe(-1) // I's filled row is row index 1
+    expect(pieceCells(i).every((c) => c.y === 0)).toBe(true)
+  })
+})
+
+describe('collides', () => {
+  it('detects the floor and walls', () => {
+    const board = emptyBoard()
+    expect(collides(board, { type: 'O', rotation: 0, x: 0, y: ROWS - 1 })).toBe(true)
+    expect(collides(board, { type: 'O', rotation: 0, x: -1, y: 0 })).toBe(true)
+    expect(collides(board, { type: 'O', rotation: 0, x: COLS - 1, y: 0 })).toBe(true)
+  })
+  it('allows a piece partly above the board', () => {
+    expect(collides(emptyBoard(), { type: 'I', rotation: 0, x: 3, y: -1 })).toBe(false)
+  })
+  it('detects overlap with a settled block', () => {
+    const board = emptyBoard()
+    board[5 * COLS + 4] = 1
+    expect(collides(board, { type: 'O', rotation: 0, x: 4, y: 4 })).toBe(true)
+  })
+})
+
+describe('merge + clearLines', () => {
+  it('locks a piece into the board', () => {
+    const board = merge(emptyBoard(), { type: 'O', rotation: 0, x: 0, y: 0 })
+    expect(board[0]).toBeGreaterThan(0)
+    expect(board[1]).toBeGreaterThan(0)
+    expect(board[COLS]).toBeGreaterThan(0)
+  })
+  it('clears a full row and drops the rows above', () => {
+    const board = emptyBoard()
+    for (let c = 0; c < COLS; c += 1) board[(ROWS - 1) * COLS + c] = 1
+    board[(ROWS - 2) * COLS + 3] = 2 // a lone block above the full row
+    const { board: next, cleared } = clearLines(board)
+    expect(cleared).toBe(1)
+    expect(next.slice((ROWS - 1) * COLS)).toEqual([0, 0, 0, 2, 0, 0, 0, 0, 0, 0])
+    expect(next.slice(0, COLS).every((v) => v === 0)).toBe(true)
+  })
+  it('clears four rows at once (a tetris)', () => {
+    let board = emptyBoard()
+    for (let r = ROWS - 4; r < ROWS; r += 1) {
+      for (let c = 0; c < COLS; c += 1) board[r * COLS + c] = 1
+    }
+    const res = clearLines(board)
+    expect(res.cleared).toBe(4)
+    expect(res.board.every((v) => v === 0)).toBe(true)
+    board = res.board
+    expect(board).toHaveLength(COLS * ROWS)
+  })
+})
+
+describe('rotate', () => {
+  it('wall-kicks off the left wall', () => {
+    // An I piece flush against the left wall, rotated vertical then back to
+    // horizontal, should kick right rather than fail.
+    const board = emptyBoard()
+    const vertical = { type: 'I' as const, rotation: 1, x: -2, y: 0 }
+    const kicked = rotate(board, vertical, 1)
+    expect(kicked).not.toBeNull()
+    expect(pieceCells(kicked!).every((c) => c.x >= 0 && c.x < COLS)).toBe(true)
+  })
+  it('returns null when no kick offset is legal', () => {
+    // Fill the whole board so any rotation collides everywhere.
+    const board: Board = Array<number>(COLS * ROWS).fill(1)
+    expect(rotate(board, { type: 'T', rotation: 0, x: 3, y: 5 }, 1)).toBeNull()
+  })
+})
+
+describe('dropRow', () => {
+  it('drops a piece to the floor on an empty board', () => {
+    const ghost = dropRow(emptyBoard(), spawnPiece('O'))
+    expect(Math.max(...pieceCells(ghost).map((c) => c.y))).toBe(ROWS - 1)
+  })
+  it('lands on top of settled blocks', () => {
+    const board = emptyBoard()
+    for (let c = 0; c < COLS; c += 1) board[(ROWS - 1) * COLS + c] = 1
+    const ghost = dropRow(board, spawnPiece('O'))
+    expect(Math.max(...pieceCells(ghost).map((c) => c.y))).toBe(ROWS - 2)
+  })
+})
+
+describe('createBag', () => {
+  it('is a permutation of all seven pieces', () => {
+    const bag = createBag(() => 0.42)
+    expect([...bag].sort()).toEqual(['I', 'J', 'L', 'O', 'S', 'T', 'Z'])
+  })
+})
+
+describe('scoring', () => {
+  it('scales line scores by level', () => {
+    expect(lineScore(1, 1)).toBe(100)
+    expect(lineScore(4, 1)).toBe(800)
+    expect(lineScore(4, 3)).toBe(2400)
+    expect(lineScore(0, 5)).toBe(0)
+  })
+  it('speeds up with level and floors at 80ms', () => {
+    expect(gravityMs(1)).toBe(800)
+    expect(gravityMs(2)).toBe(730)
+    expect(gravityMs(99)).toBe(80)
+  })
+})

--- a/src/services/tetris.spec.ts
+++ b/src/services/tetris.spec.ts
@@ -7,6 +7,7 @@ import {
   createBag,
   dropRow,
   emptyBoard,
+  fullRows,
   gravityMs,
   lineScore,
   matrixFor,
@@ -86,6 +87,28 @@ describe('merge + clearLines', () => {
     expect(res.board.every((v) => v === 0)).toBe(true)
     board = res.board
     expect(board).toHaveLength(COLS * ROWS)
+  })
+})
+
+describe('fullRows', () => {
+  it('reports no rows on an empty board', () => {
+    expect(fullRows(emptyBoard())).toEqual([])
+  })
+  it('reports the indices of completely filled rows', () => {
+    const board = emptyBoard()
+    for (let c = 0; c < COLS; c += 1) {
+      board[(ROWS - 1) * COLS + c] = 1
+      board[(ROWS - 3) * COLS + c] = 1
+    }
+    board[(ROWS - 2) * COLS + 0] = 2 // a partial row is not full
+    expect(fullRows(board)).toEqual([ROWS - 3, ROWS - 1])
+  })
+  it('matches the count reported by clearLines', () => {
+    const board = emptyBoard()
+    for (let r = ROWS - 4; r < ROWS; r += 1) {
+      for (let c = 0; c < COLS; c += 1) board[r * COLS + c] = 1
+    }
+    expect(fullRows(board)).toHaveLength(clearLines(board).cleared)
   })
 })
 

--- a/src/services/tetris.ts
+++ b/src/services/tetris.ts
@@ -1,0 +1,170 @@
+/**
+ * Tetris core logic — pure and framework-free so it can be unit tested and
+ * driven by a seeded RNG. The view owns the render/animation/gravity loop; this
+ * module handles the board, pieces, rotation (with simple wall kicks), line
+ * clears, the 7-bag randomizer, and scoring.
+ */
+
+export const COLS = 10
+export const ROWS = 20
+
+export type PieceType = 'I' | 'O' | 'T' | 'S' | 'Z' | 'J' | 'L'
+
+/** 0 = empty; 1..7 map to piece colors in COLOR_ORDER. */
+export type Board = number[]
+
+export interface Piece {
+  type: PieceType
+  rotation: number
+  x: number
+  y: number
+}
+
+export const COLOR_ORDER: PieceType[] = ['I', 'O', 'T', 'S', 'Z', 'J', 'L']
+const colorIndex = (type: PieceType): number => COLOR_ORDER.indexOf(type) + 1
+
+/** Spawn-orientation matrices; other rotations are derived by rotating these. */
+const SHAPES: Record<PieceType, number[][]> = {
+  I: [
+    [0, 0, 0, 0],
+    [1, 1, 1, 1],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ],
+  O: [
+    [1, 1],
+    [1, 1],
+  ],
+  T: [
+    [0, 1, 0],
+    [1, 1, 1],
+    [0, 0, 0],
+  ],
+  S: [
+    [0, 1, 1],
+    [1, 1, 0],
+    [0, 0, 0],
+  ],
+  Z: [
+    [1, 1, 0],
+    [0, 1, 1],
+    [0, 0, 0],
+  ],
+  J: [
+    [1, 0, 0],
+    [1, 1, 1],
+    [0, 0, 0],
+  ],
+  L: [
+    [0, 0, 1],
+    [1, 1, 1],
+    [0, 0, 0],
+  ],
+}
+
+const rotateCW = (m: number[][]): number[][] => {
+  const n = m.length
+  return m.map((row, r) => row.map((_, c) => m[n - 1 - c][r]))
+}
+
+/** The matrix for a piece type at a given rotation (0..3), normalized to 0..3. */
+export function matrixFor(type: PieceType, rotation: number): number[][] {
+  let m = SHAPES[type]
+  const times = ((rotation % 4) + 4) % 4
+  for (let i = 0; i < times; i += 1) m = rotateCW(m)
+  return m
+}
+
+/** Absolute board cells a piece currently occupies. */
+export function pieceCells(piece: Piece): Array<{ x: number; y: number }> {
+  const m = matrixFor(piece.type, piece.rotation)
+  const cells: Array<{ x: number; y: number }> = []
+  for (let r = 0; r < m.length; r += 1) {
+    for (let c = 0; c < m[r].length; c += 1) {
+      if (m[r][c]) cells.push({ x: piece.x + c, y: piece.y + r })
+    }
+  }
+  return cells
+}
+
+/** True if the piece overlaps a wall, the floor, or a settled block. */
+export function collides(board: Board, piece: Piece): boolean {
+  for (const { x, y } of pieceCells(piece)) {
+    if (x < 0 || x >= COLS || y >= ROWS) return true
+    if (y >= 0 && board[y * COLS + x]) return true // y < 0 is above the board — allowed
+  }
+  return false
+}
+
+/** A fresh piece centered at the top, with its first filled row at y = 0. */
+export function spawnPiece(type: PieceType): Piece {
+  const m = SHAPES[type]
+  const x = Math.floor((COLS - m[0].length) / 2)
+  const topOffset = m.findIndex((row) => row.some((v) => v))
+  return { type, rotation: 0, x, y: -topOffset || 0 } // avoid -0
+}
+
+/** Lock a piece into a new board (cells above the top are dropped). */
+export function merge(board: Board, piece: Piece): Board {
+  const next = board.slice()
+  const color = colorIndex(piece.type)
+  for (const { x, y } of pieceCells(piece)) {
+    if (y >= 0) next[y * COLS + x] = color
+  }
+  return next
+}
+
+/** Remove full rows, dropping everything above down. Returns the count cleared. */
+export function clearLines(board: Board): { board: Board; cleared: number } {
+  const rows: number[][] = []
+  for (let r = 0; r < ROWS; r += 1) rows.push(board.slice(r * COLS, (r + 1) * COLS))
+  const kept = rows.filter((row) => row.some((c) => c === 0))
+  const cleared = ROWS - kept.length
+  const empty = Array.from({ length: cleared }, () => Array<number>(COLS).fill(0))
+  return { board: [...empty, ...kept].flat(), cleared }
+}
+
+/**
+ * Rotate with basic wall kicks: try the rotation in place, then nudged left/right
+ * (and, for I, two cells) so rotations near a wall still succeed. Returns the
+ * kicked piece, or null if no offset is legal.
+ */
+export function rotate(board: Board, piece: Piece, dir: 1 | -1): Piece | null {
+  const rotation = ((piece.rotation + dir) % 4 + 4) % 4
+  const kicks = [0, -1, 1, -2, 2]
+  for (const dx of kicks) {
+    const candidate: Piece = { ...piece, rotation, x: piece.x + dx }
+    if (!collides(board, candidate)) return candidate
+  }
+  return null
+}
+
+/** Fisher–Yates shuffle of the 7 pieces (a "bag") using the given RNG. */
+export function createBag(rng: () => number): PieceType[] {
+  const bag = COLOR_ORDER.slice()
+  for (let i = bag.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[bag[i], bag[j]] = [bag[j], bag[i]]
+  }
+  return bag
+}
+
+/** Row at which the piece would land if dropped straight down (its ghost). */
+export function dropRow(board: Board, piece: Piece): Piece {
+  let p = piece
+  while (!collides(board, { ...p, y: p.y + 1 })) p = { ...p, y: p.y + 1 }
+  return p
+}
+
+const LINE_SCORES = [0, 100, 300, 500, 800]
+/** Points for clearing `lines` rows at the given level (1-based). */
+export function lineScore(lines: number, level: number): number {
+  return (LINE_SCORES[lines] ?? 0) * level
+}
+
+/** Gravity interval (ms per row) — faster as the level climbs. */
+export function gravityMs(level: number): number {
+  return Math.max(80, 800 - (level - 1) * 70)
+}
+
+export const emptyBoard = (): Board => Array<number>(COLS * ROWS).fill(0)

--- a/src/services/tetris.ts
+++ b/src/services/tetris.ts
@@ -114,6 +114,25 @@ export function merge(board: Board, piece: Piece): Board {
   return next
 }
 
+/**
+ * Indices of rows that are completely filled — the rows a clear will remove.
+ * The view uses this to flash those rows before collapsing them.
+ */
+export function fullRows(board: Board): number[] {
+  const rows: number[] = []
+  for (let r = 0; r < ROWS; r += 1) {
+    let full = true
+    for (let c = 0; c < COLS; c += 1) {
+      if (!board[r * COLS + c]) {
+        full = false
+        break
+      }
+    }
+    if (full) rows.push(r)
+  }
+  return rows
+}
+
 /** Remove full rows, dropping everything above down. Returns the count cleared. */
 export function clearLines(board: Board): { board: Board; cleared: number } {
   const rows: number[][] = []

--- a/src/services/tunnel.spec.ts
+++ b/src/services/tunnel.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FLAP_VX,
+  FLYER_RADIUS,
+  collides,
+  difficultyFor,
+  flap,
+  segmentAt,
+  stepFlyer,
+  type FlyerState,
+} from './tunnel'
+
+describe('flap', () => {
+  it('sets velocity toward the tapped side', () => {
+    expect(flap({ x: 0.5, vx: 0 }, 1).vx).toBe(FLAP_VX)
+    expect(flap({ x: 0.5, vx: 0 }, -1).vx).toBe(-FLAP_VX)
+  })
+})
+
+describe('stepFlyer', () => {
+  it('moves in the direction of velocity and decays it', () => {
+    const next = stepFlyer({ x: 0.5, vx: 0.5 }, 16)
+    expect(next.x).toBeGreaterThan(0.5)
+    expect(Math.abs(next.vx)).toBeLessThan(0.5)
+  })
+  it('clamps to the left edge and kills momentum', () => {
+    const next = stepFlyer({ x: FLYER_RADIUS + 0.001, vx: -1 }, 100)
+    expect(next.x).toBe(FLYER_RADIUS)
+    expect(next.vx).toBe(0)
+  })
+  it('clamps to the right edge', () => {
+    const next = stepFlyer({ x: 1 - FLYER_RADIUS - 0.001, vx: 1 }, 100)
+    expect(next.x).toBe(1 - FLYER_RADIUS)
+    expect(next.vx).toBe(0)
+  })
+  it('settles toward rest as time passes (drift decays)', () => {
+    let s: FlyerState = { x: 0.5, vx: 0.4 }
+    for (let i = 0; i < 150; i += 1) s = stepFlyer(s, 16)
+    expect(Math.abs(s.vx)).toBeLessThan(0.01)
+  })
+})
+
+describe('collides', () => {
+  const seg = { left: 0.3, right: 0.7 }
+  it('is false when the flyer fits in the gap', () => {
+    expect(collides(0.5, seg)).toBe(false)
+  })
+  it('is true when overlapping a wall', () => {
+    expect(collides(0.3 + FLYER_RADIUS - 0.001, seg)).toBe(true) // into left wall
+    expect(collides(0.7 - FLYER_RADIUS + 0.001, seg)).toBe(true) // into right wall
+  })
+})
+
+describe('segmentAt', () => {
+  it('is deterministic for a seed + row', () => {
+    expect(segmentAt(123, 5)).toEqual(segmentAt(123, 5))
+  })
+  it('always leaves a passable, in-bounds gap', () => {
+    for (let row = 0; row < 300; row += 1) {
+      const seg = segmentAt(999, row, difficultyFor(row))
+      expect(seg.left).toBeGreaterThanOrEqual(0.02)
+      expect(seg.right).toBeLessThanOrEqual(0.98)
+      // The gap must fit the flyer plus a little slack.
+      expect(seg.right - seg.left).toBeGreaterThan(2 * FLYER_RADIUS)
+    }
+  })
+})
+
+describe('difficultyFor', () => {
+  it('rises with distance and caps at 1', () => {
+    expect(difficultyFor(0)).toBe(0)
+    expect(difficultyFor(300)).toBeCloseTo(0.5)
+    expect(difficultyFor(10000)).toBe(1)
+  })
+})

--- a/src/services/tunnel.spec.ts
+++ b/src/services/tunnel.spec.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import {
+  BASE_SCROLL_SPEED,
   FLAP_VX,
   FLYER_RADIUS,
   collides,
   difficultyFor,
   flap,
+  scrollSpeedFor,
   segmentAt,
   stepFlyer,
   type FlyerState,
@@ -55,14 +57,40 @@ describe('segmentAt', () => {
   it('is deterministic for a seed + row', () => {
     expect(segmentAt(123, 5)).toEqual(segmentAt(123, 5))
   })
-  it('always leaves a passable, in-bounds gap', () => {
-    for (let row = 0; row < 300; row += 1) {
-      const seg = segmentAt(999, row, difficultyFor(row))
-      expect(seg.left).toBeGreaterThanOrEqual(0.02)
-      expect(seg.right).toBeLessThanOrEqual(0.98)
-      // The gap must fit the flyer plus a little slack.
-      expect(seg.right - seg.left).toBeGreaterThan(2 * FLYER_RADIUS)
+  it('always leaves a passable, in-bounds gap across the whole difficulty range', () => {
+    // Sweep several seeds and go well past the difficulty cap (600 rows) so the
+    // hardest, most-narrowed, most-pinched sections are exercised too.
+    for (const seed of [1, 42, 999, 0xabcdef]) {
+      for (let row = 0; row < 1200; row += 1) {
+        const seg = segmentAt(seed, row, difficultyFor(row))
+        expect(seg.left).toBeGreaterThanOrEqual(0.02)
+        expect(seg.right).toBeLessThanOrEqual(0.98)
+        // The gap must fit the circle plus a little slack.
+        expect(seg.right - seg.left).toBeGreaterThan(2 * FLYER_RADIUS)
+      }
     }
+  })
+  it('breathes — produces both roomy and pinched gaps rather than a constant width', () => {
+    let min = Infinity
+    let max = -Infinity
+    for (let row = 0; row < 400; row += 1) {
+      const gap = (({ left, right }) => right - left)(segmentAt(7, row, difficultyFor(row)))
+      min = Math.min(min, gap)
+      max = Math.max(max, gap)
+    }
+    // Wide stretches are meaningfully wider than the tightest pinches.
+    expect(max - min).toBeGreaterThan(0.1)
+  })
+  it('narrows on average as difficulty rises', () => {
+    const avgGap = (difficulty: number) => {
+      let sum = 0
+      for (let row = 0; row < 200; row += 1) {
+        const seg = segmentAt(55, row, difficulty)
+        sum += seg.right - seg.left
+      }
+      return sum / 200
+    }
+    expect(avgGap(1)).toBeLessThan(avgGap(0))
   })
 })
 
@@ -71,5 +99,25 @@ describe('difficultyFor', () => {
     expect(difficultyFor(0)).toBe(0)
     expect(difficultyFor(300)).toBeCloseTo(0.5)
     expect(difficultyFor(10000)).toBe(1)
+  })
+  it('never goes negative', () => {
+    expect(difficultyFor(-50)).toBe(0)
+  })
+})
+
+describe('scrollSpeedFor', () => {
+  it('starts at the base speed', () => {
+    expect(scrollSpeedFor(0)).toBeCloseTo(BASE_SCROLL_SPEED)
+  })
+  it('keeps accelerating with distance (strictly increasing, no cap)', () => {
+    let prev = scrollSpeedFor(0)
+    for (const d of [50, 200, 600, 1200, 5000, 20000]) {
+      const next = scrollSpeedFor(d)
+      expect(next).toBeGreaterThan(prev)
+      prev = next
+    }
+  })
+  it('is meaningfully faster deep into a run than at the start', () => {
+    expect(scrollSpeedFor(2000)).toBeGreaterThan(scrollSpeedFor(0) * 1.5)
   })
 })

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -47,23 +47,51 @@ export function collides(x: number, seg: Segment): boolean {
   return x - FLYER_RADIUS < seg.left || x + FLYER_RADIUS > seg.right
 }
 
+/** Smallest half-gap the course will ever produce, so a passage always fits. */
+export const MIN_HALF_GAP = 0.1
+
 /**
  * Generate the tunnel as a deterministic function of a seed and a row index, so
- * the course is reproducible and endless. The gap drifts left/right smoothly and
- * narrows as `difficulty` (0..1) rises. Always leaves a passable gap.
+ * the course is reproducible and endless. The corridor does three things that
+ * make the run less monotonous, all scaling with `difficulty` (0..1):
+ *   - the centerline weaves (a wide slow wave plus a faster seed-shifted wobble),
+ *   - it "breathes" between roomy stretches and tighter pinch points, and
+ *   - the whole gap narrows.
+ * It always leaves a passable, in-bounds gap wider than the circle.
  */
 export function segmentAt(seed: number, row: number, difficulty = 0): Segment {
   const rand = mulberry32((seed + row * 2654435761) >>> 0)
   const t = row * 0.15
-  // Smooth drifting centerline kept away from the edges.
-  const center = 0.5 + 0.26 * Math.sin(t) + 0.1 * Math.sin(t * 2.3 + seed)
-  const halfGap = Math.max(0.1, 0.28 - 0.12 * difficulty + 0.02 * (rand() - 0.5))
+  // Weaving centerline: bends more, and wobbles faster, the deeper you go.
+  const sway = 0.24 + 0.06 * difficulty
+  const wobble = (0.08 + 0.05 * difficulty) * Math.sin(t * 2.3 + seed)
+  const center = 0.5 + sway * Math.sin(t) + wobble
+  // Breathing width: a slow wave pinches the tunnel in and lets it back out,
+  // with deeper pinches as difficulty rises, on top of the overall narrowing.
+  const breathe = (0.05 + 0.03 * difficulty) * (0.5 + 0.5 * Math.sin(t * 0.5 + seed))
+  const baseHalf = 0.27 - 0.13 * difficulty
+  const jitter = 0.02 * (rand() - 0.5)
+  const halfGap = Math.max(MIN_HALF_GAP, baseHalf - breathe + jitter)
   const left = Math.max(0.02, center - halfGap)
   const right = Math.min(0.98, center + halfGap)
   return { left, right }
 }
 
-/** Difficulty ramps with distance, capped so it stays playable. */
+/** Difficulty ramps with distance, capped so course shaping stays playable. */
 export function difficultyFor(distance: number): number {
-  return Math.min(1, distance / 600)
+  return Math.min(1, Math.max(0, distance) / 600)
+}
+
+/** Scroll speed at the start of a run, in course rows per second. */
+export const BASE_SCROLL_SPEED = 2.6
+
+/**
+ * Scroll speed (rows/second) as a function of distance travelled. It keeps
+ * accelerating for the whole run — a quick early ramp tied to `difficulty`
+ * plus an unbounded but gently slowing logarithmic creep — so the tunnel never
+ * settles into a constant, boring pace. Strictly increasing in distance.
+ */
+export function scrollSpeedFor(distance: number): number {
+  const d = Math.max(0, distance)
+  return BASE_SCROLL_SPEED + 3.4 * difficultyFor(d) + Math.log1p(d / 200)
 }

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -1,0 +1,69 @@
+/**
+ * Vertical tunnel flapper — physics and course generation, kept pure so the
+ * game loop in the view stays a thin driver and the tricky bits are testable.
+ *
+ * The tunnel scrolls downward past a fixed-height flyer, so "distance" (score)
+ * grows as the course advances. Every length is a fraction of the play WIDTH,
+ * so the model is resolution-independent; the view multiplies by its pixels.
+ */
+
+import { mulberry32 } from './seed'
+
+export interface FlyerState {
+  x: number // center, 0..1
+  vx: number // horizontal velocity, fraction of width per second
+}
+
+/** A horizontal slice of the tunnel: passable gap between left and right walls. */
+export interface Segment {
+  left: number
+  right: number
+}
+
+export const FLAP_VX = 0.9 // horizontal speed imparted by a flap
+export const FLYER_RADIUS = 0.045 // as a fraction of width
+
+/**
+ * Advance the flyer horizontally. Velocity decays exponentially so taps feel
+ * snappy but drift settles. dtMs is the frame time in milliseconds.
+ */
+export function stepFlyer(state: FlyerState, dtMs: number): FlyerState {
+  const dt = dtMs / 1000
+  const vx = state.vx * Math.exp(-3 * dt)
+  const x = state.x + vx * dt
+  // Clamp to the play area; hitting the outer bound kills horizontal momentum.
+  if (x < FLYER_RADIUS) return { x: FLYER_RADIUS, vx: 0 }
+  if (x > 1 - FLYER_RADIUS) return { x: 1 - FLYER_RADIUS, vx: 0 }
+  return { x, vx }
+}
+
+/** Apply a flap toward -1 (left) or +1 (right). */
+export function flap(state: FlyerState, dir: -1 | 1): FlyerState {
+  return { ...state, vx: dir * FLAP_VX }
+}
+
+/** True if the flyer at center x overlaps either wall of a segment. */
+export function collides(x: number, seg: Segment): boolean {
+  return x - FLYER_RADIUS < seg.left || x + FLYER_RADIUS > seg.right
+}
+
+/**
+ * Generate the tunnel as a deterministic function of a seed and a row index, so
+ * the course is reproducible and endless. The gap drifts left/right smoothly and
+ * narrows as `difficulty` (0..1) rises. Always leaves a passable gap.
+ */
+export function segmentAt(seed: number, row: number, difficulty = 0): Segment {
+  const rand = mulberry32((seed + row * 2654435761) >>> 0)
+  const t = row * 0.15
+  // Smooth drifting centerline kept away from the edges.
+  const center = 0.5 + 0.26 * Math.sin(t) + 0.1 * Math.sin(t * 2.3 + seed)
+  const halfGap = Math.max(0.1, 0.28 - 0.12 * difficulty + 0.02 * (rand() - 0.5))
+  const left = Math.max(0.02, center - halfGap)
+  const right = Math.min(0.98, center + halfGap)
+  return { left, right }
+}
+
+/** Difficulty ramps with distance, capped so it stays playable. */
+export function difficultyFor(distance: number): number {
+  return Math.min(1, distance / 600)
+}

--- a/src/services/wallJump.spec.ts
+++ b/src/services/wallJump.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MAX_CHARGE_MS,
+  MAX_JUMP_VY,
+  MIN_JUMP_VY,
+  WALL_X,
+  chargeToVy,
+  hitsSpike,
+  initialNinja,
+  jump,
+  spikeAt,
+  stepNinja,
+  type NinjaState,
+} from './wallJump'
+
+describe('chargeToVy', () => {
+  it('maps hold duration to jump speed, clamped', () => {
+    expect(chargeToVy(0)).toBe(MIN_JUMP_VY)
+    expect(chargeToVy(MAX_CHARGE_MS)).toBe(MAX_JUMP_VY)
+    expect(chargeToVy(9999)).toBe(MAX_JUMP_VY)
+    expect(chargeToVy(MAX_CHARGE_MS / 2)).toBeCloseTo((MIN_JUMP_VY + MAX_JUMP_VY) / 2)
+  })
+})
+
+describe('jump', () => {
+  it('launches toward the opposite wall and goes airborne', () => {
+    const j = jump(initialNinja(), MAX_CHARGE_MS) // on left wall
+    expect(j.airborne).toBe(true)
+    expect(j.vx).toBeGreaterThan(0) // moving right, away from the left wall
+    expect(j.vy).toBe(MAX_JUMP_VY)
+  })
+  it('is a no-op while already airborne', () => {
+    const air: NinjaState = { ...initialNinja(), airborne: true }
+    expect(jump(air, 200)).toBe(air)
+  })
+})
+
+describe('stepNinja', () => {
+  it('does nothing while grounded', () => {
+    const g = initialNinja()
+    expect(stepNinja(g, 16)).toBe(g)
+  })
+  it('applies gravity to vertical velocity while airborne', () => {
+    const air = jump(initialNinja(), MAX_CHARGE_MS)
+    const next = stepNinja(air, 16)
+    expect(next.vy).toBeLessThan(air.vy)
+  })
+  it('clings to the opposite wall on arrival, flipping side and grounding', () => {
+    let s = jump(initialNinja(), MAX_CHARGE_MS) // from left → flying right
+    for (let i = 0; i < 200 && s.airborne; i += 1) s = stepNinja(s, 16)
+    expect(s.airborne).toBe(false)
+    expect(s.side).toBe(1)
+    expect(s.x).toBeCloseTo(WALL_X['1'])
+  })
+})
+
+describe('spikeAt', () => {
+  it('is deterministic and picks a single wall', () => {
+    const a = spikeAt(77, 3)
+    expect(spikeAt(77, 3)).toEqual(a)
+    expect([-1, 1]).toContain(a.side)
+    expect(a.y).toBeGreaterThan(0)
+  })
+})
+
+describe('hitsSpike', () => {
+  it('impales a ninja clinging at a spike on the same wall', () => {
+    const seed = 5
+    const spike = spikeAt(seed, 4)
+    const s: NinjaState = { side: spike.side, x: WALL_X[spike.side], y: spike.y, vx: 0, vy: 0, airborne: false }
+    expect(hitsSpike(s, seed)).toBe(true)
+  })
+  it('is safe on the opposite wall from the spike', () => {
+    const seed = 5
+    const spike = spikeAt(seed, 4)
+    const other = (spike.side * -1) as -1 | 1
+    const s: NinjaState = { side: other, x: WALL_X[other], y: spike.y, vx: 0, vy: 0, airborne: false }
+    expect(hitsSpike(s, seed)).toBe(false)
+  })
+  it('never triggers while airborne', () => {
+    const seed = 5
+    const spike = spikeAt(seed, 4)
+    const s: NinjaState = { side: spike.side, x: 0.5, y: spike.y, vx: 0.9, vy: 0, airborne: true }
+    expect(hitsSpike(s, seed)).toBe(false)
+  })
+  it('is safe at the start (no spike near y=0)', () => {
+    expect(hitsSpike(initialNinja(), 5)).toBe(false)
+  })
+})

--- a/src/services/wallJump.spec.ts
+++ b/src/services/wallJump.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
+  LAVA_MAX_SPEED,
   MAX_CHARGE_MS,
+  MAX_JUMP_HEIGHT,
   MAX_JUMP_VY,
   MIN_JUMP_VY,
   WALL_X,
@@ -8,7 +10,10 @@ import {
   hitsSpike,
   initialNinja,
   jump,
+  lavaSpeed,
+  predictTrajectory,
   spikeAt,
+  stepLava,
   stepNinja,
   type NinjaState,
 } from './wallJump'
@@ -19,6 +24,65 @@ describe('chargeToVy', () => {
     expect(chargeToVy(MAX_CHARGE_MS)).toBe(MAX_JUMP_VY)
     expect(chargeToVy(9999)).toBe(MAX_JUMP_VY)
     expect(chargeToVy(MAX_CHARGE_MS / 2)).toBeCloseTo((MIN_JUMP_VY + MAX_JUMP_VY) / 2)
+  })
+})
+
+describe('jump power scaling and bounds', () => {
+  const apex = (holdMs: number): number => {
+    let s = jump(initialNinja(), holdMs)
+    let peak = s.y
+    for (let i = 0; i < 200 && s.airborne; i += 1) {
+      s = stepNinja(s, 16)
+      peak = Math.max(peak, s.y)
+    }
+    return peak
+  }
+
+  it('gives a big difference between a tap and a full hold', () => {
+    // A short tap barely rises; a full hold arcs well over a climb unit higher.
+    expect(apex(MAX_CHARGE_MS) - apex(0)).toBeGreaterThan(1)
+  })
+
+  it('caps the apex at MAX_JUMP_HEIGHT even for an absurd hold', () => {
+    const eps = 0.05
+    expect(apex(MAX_CHARGE_MS)).toBeLessThanOrEqual(MAX_JUMP_HEIGHT + eps)
+    expect(apex(999999)).toBeLessThanOrEqual(MAX_JUMP_HEIGHT + eps)
+  })
+})
+
+describe('predictTrajectory', () => {
+  it('is empty when already airborne', () => {
+    expect(predictTrajectory({ ...initialNinja(), airborne: true }, 300)).toEqual([])
+  })
+
+  it('grows the arc with a longer hold', () => {
+    const peak = (holdMs: number) => Math.max(...predictTrajectory(initialNinja(), holdMs).map((p) => p.y))
+    expect(peak(MAX_CHARGE_MS)).toBeGreaterThan(peak(0))
+  })
+
+  it('never leaves the playfield: x within the walls, apex clamped', () => {
+    // Even a huge charge must stay between the walls and under the height cap.
+    const path = predictTrajectory(initialNinja(), 999999)
+    for (const p of path) {
+      expect(p.x).toBeGreaterThanOrEqual(WALL_X['-1'] - 1e-9)
+      expect(p.x).toBeLessThanOrEqual(WALL_X['1'] + 1e-9)
+      expect(p.y).toBeLessThanOrEqual(MAX_JUMP_HEIGHT + 0.05)
+    }
+    // Ends clinging to the opposite (right) wall.
+    expect(path[path.length - 1].x).toBeCloseTo(WALL_X['1'])
+  })
+})
+
+describe('lava', () => {
+  it('accelerates: rises faster over time, clamped to a ceiling', () => {
+    expect(lavaSpeed(5000)).toBeGreaterThan(lavaSpeed(0))
+    expect(lavaSpeed(1_000_000)).toBeCloseTo(LAVA_MAX_SPEED)
+  })
+
+  it('stepLava climbs more in a later frame than an early one', () => {
+    const early = stepLava(0, 0, 100) // first 100ms
+    const late = stepLava(0, 8000, 100) // 100ms, 8s into the run
+    expect(late).toBeGreaterThan(early)
   })
 })
 
@@ -77,11 +141,18 @@ describe('hitsSpike', () => {
     const s: NinjaState = { side: other, x: WALL_X[other], y: spike.y, vx: 0, vy: 0, airborne: false }
     expect(hitsSpike(s, seed)).toBe(false)
   })
-  it('never triggers while airborne', () => {
+  it('is safe airborne out in the middle of the shaft', () => {
     const seed = 5
     const spike = spikeAt(seed, 4)
     const s: NinjaState = { side: spike.side, x: 0.5, y: spike.y, vx: 0.9, vy: 0, airborne: true }
     expect(hitsSpike(s, seed)).toBe(false)
+  })
+  it('kills the ninja that flies into a spike near its wall', () => {
+    const seed = 5
+    const spike = spikeAt(seed, 4)
+    // Airborne but pressed up against the spike's wall within its reach.
+    const s: NinjaState = { side: spike.side, x: WALL_X[spike.side], y: spike.y, vx: 0.9, vy: 0, airborne: true }
+    expect(hitsSpike(s, seed)).toBe(true)
   })
   it('is safe at the start (no spike near y=0)', () => {
     expect(hitsSpike(initialNinja(), 5)).toBe(false)

--- a/src/services/wallJump.ts
+++ b/src/services/wallJump.ts
@@ -1,0 +1,117 @@
+/**
+ * Ninja wall-jump — physics and hazard generation, pure and testable. The ninja
+ * clings to the left or right wall and jumps across to the other wall; hold
+ * longer to jump higher. Spikes jut from the walls; touching one ends the run.
+ *
+ * Coordinates: x in [0,1] across the shaft; y in "climb units" that only
+ * increase. The view scales both to pixels. Gravity/velocity are per second.
+ */
+
+import { mulberry32 } from './seed'
+
+export type Wall = -1 | 1 // -1 = left, +1 = right
+
+export interface NinjaState {
+  side: Wall // wall currently clung to (when grounded)
+  x: number // 0 (left wall) .. 1 (right wall)
+  y: number // climb height, only grows
+  vx: number // horizontal velocity
+  vy: number // vertical velocity (up is positive)
+  airborne: boolean
+}
+
+export const GRAVITY = 2.6 // downward accel (climb units / s^2)
+export const WALL_X = { '-1': 0.12, '1': 0.88 } as const // cling x per wall
+export const JUMP_VX = 0.9 // horizontal jump speed
+export const MIN_JUMP_VY = 1.2
+export const MAX_JUMP_VY = 2.6
+export const MAX_CHARGE_MS = 420 // press duration for a full-power jump
+
+export const initialNinja = (): NinjaState => ({
+  side: -1,
+  x: WALL_X['-1'],
+  y: 0,
+  vx: 0,
+  vy: 0,
+  airborne: false,
+})
+
+/** Map a hold duration (ms) to jump vertical speed, clamped and eased linearly. */
+export function chargeToVy(holdMs: number): number {
+  const t = Math.max(0, Math.min(1, holdMs / MAX_CHARGE_MS))
+  return MIN_JUMP_VY + t * (MAX_JUMP_VY - MIN_JUMP_VY)
+}
+
+/**
+ * Launch the ninja off its current wall toward the other one. Higher `holdMs`
+ * gives more upward speed. No-op if already airborne.
+ */
+export function jump(state: NinjaState, holdMs: number): NinjaState {
+  if (state.airborne) return state
+  return {
+    ...state,
+    airborne: true,
+    vx: -state.side * JUMP_VX, // toward the opposite wall
+    vy: chargeToVy(holdMs),
+  }
+}
+
+/**
+ * Advance physics by dtMs. While airborne, gravity pulls the ninja down and it
+ * flies toward the far wall; on reaching a wall it clings (vx/vy reset) at the
+ * higher of its current height (you never slide back down below a wall touch).
+ */
+export function stepNinja(state: NinjaState, dtMs: number): NinjaState {
+  if (!state.airborne) return state
+  const dt = dtMs / 1000
+  const vy = state.vy - GRAVITY * dt
+  const x = state.x + state.vx * dt
+  const y = state.y + vy * dt
+
+  const leftX = WALL_X['-1']
+  const rightX = WALL_X['1']
+  if (x <= leftX && state.vx < 0) {
+    return { side: -1, x: leftX, y, vx: 0, vy: 0, airborne: false }
+  }
+  if (x >= rightX && state.vx > 0) {
+    return { side: 1, x: rightX, y, vx: 0, vy: 0, airborne: false }
+  }
+  return { ...state, x, y, vy }
+}
+
+/** A spike hazard on one wall at a given height, with a vertical half-extent. */
+export interface Spike {
+  side: Wall
+  y: number
+  half: number // half-height of the spike's danger zone (climb units)
+}
+
+/**
+ * Deterministic, endless spikes. Spikes are spaced roughly every `SPACING`
+ * climb units; each row places a spike on one wall (never both, so a jump is
+ * always survivable). Density is fixed; the challenge comes from timing.
+ */
+export const SPIKE_SPACING = 1.4
+export const SPIKE_HALF = 0.32
+
+export function spikeAt(seed: number, index: number): Spike {
+  const rand = mulberry32((seed + index * 2654435761) >>> 0)
+  const side: Wall = rand() < 0.5 ? -1 : 1
+  const jitter = (rand() - 0.5) * 0.5
+  return { side, y: (index + 1) * SPIKE_SPACING + jitter, half: SPIKE_HALF }
+}
+
+/** Whether the ninja (clinging or passing a wall) is impaled on any nearby spike. */
+export function hitsSpike(state: NinjaState, seed: number): boolean {
+  // Only a spike on the wall the ninja is touching can hit it.
+  if (state.airborne) {
+    // In-air: check the wall it's closest to only if actually against it.
+    return false
+  }
+  const nearestIndex = Math.round(state.y / SPIKE_SPACING)
+  for (let i = Math.max(0, nearestIndex - 1); i <= nearestIndex + 1; i += 1) {
+    const spike = spikeAt(seed, i)
+    if (spike.side === state.side && Math.abs(spike.y - state.y) < spike.half) return true
+  }
+  return false
+}

--- a/src/services/wallJump.ts
+++ b/src/services/wallJump.ts
@@ -23,9 +23,16 @@ export interface NinjaState {
 export const GRAVITY = 2.6 // downward accel (climb units / s^2)
 export const WALL_X = { '-1': 0.12, '1': 0.88 } as const // cling x per wall
 export const JUMP_VX = 0.9 // horizontal jump speed
-export const MIN_JUMP_VY = 1.2
-export const MAX_JUMP_VY = 2.6
-export const MAX_CHARGE_MS = 420 // press duration for a full-power jump
+
+// A wide gap between a tap and a full hold makes charging feel meaningful: a
+// short tap barely clears the shaft (and can even dip), while a full charge
+// arcs high. The apex is capped by MAX_JUMP_HEIGHT so the ninja can never fly
+// off the top of the view, and horizontal motion is bounded by the two walls,
+// so a jump is always kept within screen bounds.
+export const MAX_JUMP_HEIGHT = 1.9 // max apex above the launch point (climb units)
+export const MIN_JUMP_VY = 0.5
+export const MAX_JUMP_VY = Math.sqrt(2 * GRAVITY * MAX_JUMP_HEIGHT) // apex === MAX_JUMP_HEIGHT
+export const MAX_CHARGE_MS = 620 // press duration for a full-power jump
 
 export const initialNinja = (): NinjaState => ({
   side: -1,
@@ -79,6 +86,29 @@ export function stepNinja(state: NinjaState, dtMs: number): NinjaState {
   return { ...state, x, y, vy }
 }
 
+/**
+ * Predict the flight path of a jump of the given hold duration, as world-space
+ * {x, y} points from launch until the ninja clings to the far wall (or a step
+ * cap). Used to draw the charge arc preview; because it reuses `jump`/`stepNinja`
+ * the preview matches the real leap, and both are bounded (x between the walls,
+ * apex ≤ MAX_JUMP_HEIGHT) so the arc never leaves the playfield.
+ */
+export function predictTrajectory(
+  state: NinjaState,
+  holdMs: number,
+  maxSteps = 60,
+  dtMs = 16,
+): { x: number; y: number }[] {
+  if (state.airborne) return []
+  let s = jump(state, holdMs)
+  const points: { x: number; y: number }[] = [{ x: s.x, y: s.y }]
+  for (let i = 0; i < maxSteps && s.airborne; i += 1) {
+    s = stepNinja(s, dtMs)
+    points.push({ x: s.x, y: s.y })
+  }
+  return points
+}
+
 /** A spike hazard on one wall at a given height, with a vertical half-extent. */
 export interface Spike {
   side: Wall
@@ -93,6 +123,7 @@ export interface Spike {
  */
 export const SPIKE_SPACING = 1.4
 export const SPIKE_HALF = 0.32
+export const SPIKE_REACH = 0.09 // how far a spike's danger zone juts in from its wall (x units)
 
 export function spikeAt(seed: number, index: number): Spike {
   const rand = mulberry32((seed + index * 2654435761) >>> 0)
@@ -101,17 +132,43 @@ export function spikeAt(seed: number, index: number): Spike {
   return { side, y: (index + 1) * SPIKE_SPACING + jitter, half: SPIKE_HALF }
 }
 
-/** Whether the ninja (clinging or passing a wall) is impaled on any nearby spike. */
+/**
+ * Whether the ninja is impaled on a nearby spike. A spike can catch the ninja
+ * whether it is clinging to that wall or still airborne but within the spike's
+ * reach of it — so flying into a spike is fatal, not only landing on one. When
+ * the ninja is out in the middle of the shaft (near neither wall) it is safe.
+ */
 export function hitsSpike(state: NinjaState, seed: number): boolean {
-  // Only a spike on the wall the ninja is touching can hit it.
-  if (state.airborne) {
-    // In-air: check the wall it's closest to only if actually against it.
-    return false
-  }
+  const leftX = WALL_X['-1']
+  const rightX = WALL_X['1']
+  let side: Wall | 0 = 0
+  if (state.x <= leftX + SPIKE_REACH) side = -1
+  else if (state.x >= rightX - SPIKE_REACH) side = 1
+  if (side === 0) return false
+
   const nearestIndex = Math.round(state.y / SPIKE_SPACING)
   for (let i = Math.max(0, nearestIndex - 1); i <= nearestIndex + 1; i += 1) {
     const spike = spikeAt(seed, i)
-    if (spike.side === state.side && Math.abs(spike.y - state.y) < spike.half) return true
+    if (spike.side === side && Math.abs(spike.y - state.y) < spike.half) return true
   }
   return false
+}
+
+// --- Rising lava --------------------------------------------------------------
+// The lava rises from below and its speed accelerates the longer the run lasts,
+// so dawdling gets punished more and more. Speed is a function of elapsed time,
+// capped so it stays outrunnable in principle.
+export const LAVA_BASE_SPEED = 0.35 // rise speed at the start (climb units / s)
+export const LAVA_ACCEL = 0.16 // extra rise speed gained per second elapsed
+export const LAVA_MAX_SPEED = 3.2 // ceiling on the rise speed (climb units / s)
+
+/** Current lava rise speed for a run that has been going `elapsedMs` ms. */
+export function lavaSpeed(elapsedMs: number): number {
+  const t = Math.max(0, elapsedMs) / 1000
+  return Math.min(LAVA_MAX_SPEED, LAVA_BASE_SPEED + LAVA_ACCEL * t)
+}
+
+/** Advance the lava surface by dtMs, using the (accelerating) speed for `elapsedMs`. */
+export function stepLava(dangerY: number, elapsedMs: number, dtMs: number): number {
+  return dangerY + (lavaSpeed(elapsedMs) * dtMs) / 1000
 }

--- a/src/views/BallBounceView.vue
+++ b/src/views/BallBounceView.vue
@@ -8,13 +8,14 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import GameToolbar from '@/components/GameToolbar.vue'
 import { useSquareFit } from '@/composables/useSquareFit'
+import { copyToClipboard } from '@/services/share'
 import {
   BALL_RADIUS,
   BOUNCE_VY,
-  PLATFORM_SPACING,
   type Ball,
   nearestPlatformIndex,
   platformAt,
+  platformBroken,
   stepBall,
   tryBounce,
 } from '@/services/ballBounce'
@@ -24,12 +25,13 @@ const displayW = computed(() => Math.round(boardPx.value * 0.66))
 const displayH = computed(() => boardPx.value)
 
 const BEST_KEY = 'ballbounce-best'
-const UNITS_VISIBLE = 9
+const UNITS_VISIBLE = 7 // keeps at most ~5 shelves on screen at the tightest spacing
 const BALL_SCREEN = 0.42
 
 const canvasEl = ref<HTMLCanvasElement | null>(null)
 const state = ref<'idle' | 'running' | 'over'>('idle')
 const best = ref(0)
+const snackbar = ref(false)
 
 let ball: Ball = { x: 0.5, y: BALL_RADIUS, vx: 0, vy: BOUNCE_VY }
 let seed = 1
@@ -41,6 +43,8 @@ let leftKey = false
 let rightKey = false
 let raf = 0
 let lastTs = 0
+// How many times each shelf (by index) has been bounced — shelves break at MAX_BOUNCES.
+const bounceCounts = new Map<number, number>()
 
 const score = computed(() => Math.max(0, Math.round(maxY * 10)))
 const fallLimit = (1 - BALL_SCREEN) * UNITS_VISIBLE
@@ -55,6 +59,7 @@ const reset = () => {
   pointerActive = false
   leftKey = false
   rightKey = false
+  bounceCounts.clear()
 }
 
 const gameOver = () => {
@@ -96,16 +101,21 @@ const draw = () => {
 
   const unit = H / UNITS_VISIBLE
 
-  // Platforms in view
-  const lo = Math.floor((cameraY - (1 - BALL_SCREEN) * UNITS_VISIBLE) / PLATFORM_SPACING) - 1
-  const hi = Math.ceil((cameraY + BALL_SCREEN * UNITS_VISIBLE) / PLATFORM_SPACING) + 1
-  for (let i = Math.max(0, lo); i <= hi; i += 1) {
+  // Shelves in view (skip any that have broken away).
+  const topY = cameraY + BALL_SCREEN * UNITS_VISIBLE
+  const botY = cameraY - (1 - BALL_SCREEN) * UNITS_VISIBLE
+  const lo = Math.max(0, nearestPlatformIndex(botY) - 1)
+  const hi = nearestPlatformIndex(topY) + 1
+  for (let i = lo; i <= hi; i += 1) {
+    const count = bounceCounts.get(i) ?? 0
+    if (platformBroken(count)) continue
     const p = platformAt(seed, i)
     const sy = yToScreen(p.y, H, unit)
     if (sy < -20 || sy > H + 20) continue
     const pw = p.width * W
     const px = p.x * W - pw / 2
-    ctx.fillStyle = i === 0 ? '#475569' : '#34d399'
+    // Grey start shelf; green normally; amber once it's been bounced (about to break).
+    ctx.fillStyle = i === 0 ? '#475569' : count > 0 ? '#f59e0b' : '#34d399'
     ctx.fillRect(px, sy - 6, pw, 10)
     ctx.fillStyle = 'rgba(255,255,255,0.15)'
     ctx.fillRect(px, sy - 6, pw, 3)
@@ -131,13 +141,17 @@ const tick = (ts: number) => {
   const prevY = ball.y
   ball = stepBall(ball, steer, dt)
 
-  // Bounce off any platform the ball crossed downward this step.
+  // Bounce off the top of any (unbroken) shelf the ball crossed downward this
+  // step, and count the bounce so the shelf breaks after MAX_BOUNCES.
   if (ball.vy <= 0) {
     const center = nearestPlatformIndex(ball.y)
-    for (let i = Math.max(0, center - 1); i <= center + 2; i += 1) {
+    for (let i = Math.max(0, center - 2); i <= center + 2; i += 1) {
+      const count = bounceCounts.get(i) ?? 0
+      if (platformBroken(count)) continue
       const bounced = tryBounce(ball, prevY, platformAt(seed, i))
       if (bounced) {
         ball = bounced
+        bounceCounts.set(i, count + 1)
         break
       }
     }
@@ -205,6 +219,14 @@ const onKeyUp = (e: KeyboardEvent) => {
   applyKeySteer()
 }
 
+const share = async () => {
+  const url = window.location.origin + '/ball-bounce'
+  await copyToClipboard(
+    `I climbed to ${score.value} in Ball Bounce${score.value === best.value && score.value > 0 ? ' (my best!)' : ''}. Beat me!\n${url}`,
+  )
+  snackbar.value = true
+}
+
 watch([displayW, displayH], () => {
   if (state.value !== 'running') draw()
 })
@@ -229,7 +251,7 @@ onBeforeUnmount(() => {
 
 <template>
   <v-container class="py-6" max-width="600">
-    <GameToolbar title="Ball Bounce">
+    <GameToolbar title="Ball Bounce" shareable @share="share">
       <template #intro>
         The ball bounces on its own — steer <strong>left</strong> and <strong>right</strong> (hold a
         side, or arrow keys) to land on the next platform. The view only climbs; fall off the bottom
@@ -244,10 +266,16 @@ onBeforeUnmount(() => {
           <li>Desktop: <span class="k">←</span>/<span class="k">→</span> or <span class="k">A</span>/<span class="k">D</span>.</li>
           <li>The ball wraps around the screen edges.</li>
         </ul>
+        <h3>Rules</h3>
+        <ul>
+          <li>You only bounce off the <strong>top</strong> of a shelf, and only while falling.</li>
+          <li>Shelves <strong>break after two bounces</strong> (they turn amber first) — keep climbing, you can't camp on one.</li>
+          <li>Shelves spread <strong>further apart the higher you climb</strong>, so it gets harder.</li>
+        </ul>
         <h3>Tips</h3>
         <ul>
-          <li>Line up the next platform while you're rising — you can't change a miss once you're falling past it.</li>
-          <li>Use the wrap: sometimes the quickest path to a platform is off the far edge.</li>
+          <li>Line up the next shelf while you're rising — you can't change a miss once you're falling past it.</li>
+          <li>Use the wrap: sometimes the quickest path to a shelf is off the far edge.</li>
         </ul>
       </template>
     </GameToolbar>
@@ -274,14 +302,18 @@ onBeforeUnmount(() => {
           <v-btn color="primary" variant="flat" @click="start">Start</v-btn>
         </template>
         <template v-else>
-          <p class="text-h5 mb-1">Dropped!</p>
+          <p class="text-h5 mb-1">Game over</p>
           <p class="text-body-2 mb-3">
             Height {{ score }}<span v-if="score === best && score > 0"> — new best!</span>
           </p>
-          <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="start">Bounce again</v-btn>
+          <div class="d-flex ga-2">
+            <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="start">Bounce again</v-btn>
+            <v-btn variant="tonal" prepend-icon="mdi-share-variant" @click="share">Share</v-btn>
+          </div>
         </template>
       </div>
     </div>
+    <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Score copied — challenge a friend!</v-snackbar>
   </v-container>
 </template>
 

--- a/src/views/BallBounceView.vue
+++ b/src/views/BallBounceView.vue
@@ -36,6 +36,9 @@ let seed = 1
 let maxY = 0
 let cameraY = 0
 let steer: -1 | 0 | 1 = 0
+let pointerActive = false
+let leftKey = false
+let rightKey = false
 let raf = 0
 let lastTs = 0
 
@@ -49,6 +52,9 @@ const reset = () => {
   maxY = 0
   cameraY = 0
   steer = 0
+  pointerActive = false
+  leftKey = false
+  rightKey = false
 }
 
 const gameOver = () => {
@@ -56,6 +62,9 @@ const gameOver = () => {
   cancelAnimationFrame(raf)
   raf = 0
   steer = 0
+  pointerActive = false
+  leftKey = false
+  rightKey = false
   if (score.value > best.value) {
     best.value = score.value
     try {
@@ -160,32 +169,40 @@ const steerFromX = (clientX: number, el: HTMLElement) => {
 }
 
 const onPointerDown = (e: PointerEvent) => {
-  if (state.value !== 'running') {
-    start()
-    return
-  }
-  steerFromX(e.clientX, e.currentTarget as HTMLElement)
+  if (state.value !== 'running') start()
+  pointerActive = true
+  steerFromX(e.clientX, e.currentTarget as HTMLElement) // steer even on the starting press
 }
 const onPointerMove = (e: PointerEvent) => {
-  if (state.value === 'running' && steer !== 0) steerFromX(e.clientX, e.currentTarget as HTMLElement)
+  if (state.value === 'running' && pointerActive) steerFromX(e.clientX, e.currentTarget as HTMLElement)
 }
 const stopSteer = () => {
+  pointerActive = false
   steer = 0
 }
 
+// Track both arrow keys so releasing one doesn't cancel the other still held.
+const applyKeySteer = () => {
+  steer = leftKey === rightKey ? 0 : leftKey ? -1 : 1
+}
 const onKeyDown = (e: KeyboardEvent) => {
   if (e.key === 'ArrowLeft' || e.key === 'a') {
     e.preventDefault()
-    if (state.value === 'running') steer = -1
-    else start()
+    if (state.value !== 'running') start()
+    leftKey = true
+    applyKeySteer()
   } else if (e.key === 'ArrowRight' || e.key === 'd') {
     e.preventDefault()
-    if (state.value === 'running') steer = 1
-    else start()
+    if (state.value !== 'running') start()
+    rightKey = true
+    applyKeySteer()
   }
 }
 const onKeyUp = (e: KeyboardEvent) => {
-  if (['ArrowLeft', 'ArrowRight', 'a', 'd'].includes(e.key)) steer = 0
+  if (e.key === 'ArrowLeft' || e.key === 'a') leftKey = false
+  else if (e.key === 'ArrowRight' || e.key === 'd') rightKey = false
+  else return
+  applyKeySteer()
 }
 
 watch([displayW, displayH], () => {

--- a/src/views/BallBounceView.vue
+++ b/src/views/BallBounceView.vue
@@ -1,0 +1,296 @@
+<script setup lang="ts">
+/**
+ * Ball Bounce — a doodle-jump climber. The ball bounces automatically off
+ * platforms; you steer left/right (hold a side, or arrow keys) to line up the
+ * next platform. The camera only rises — fall below the bottom and it's over.
+ * Canvas-rendered; physics/platforms come from services/ballBounce.
+ */
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { useSquareFit } from '@/composables/useSquareFit'
+import {
+  BALL_RADIUS,
+  BOUNCE_VY,
+  PLATFORM_SPACING,
+  type Ball,
+  nearestPlatformIndex,
+  platformAt,
+  stepBall,
+  tryBounce,
+} from '@/services/ballBounce'
+
+const { el: boardEl, px: boardPx } = useSquareFit(150)
+const displayW = computed(() => Math.round(boardPx.value * 0.66))
+const displayH = computed(() => boardPx.value)
+
+const BEST_KEY = 'ballbounce-best'
+const UNITS_VISIBLE = 9
+const BALL_SCREEN = 0.42
+
+const canvasEl = ref<HTMLCanvasElement | null>(null)
+const state = ref<'idle' | 'running' | 'over'>('idle')
+const best = ref(0)
+
+let ball: Ball = { x: 0.5, y: BALL_RADIUS, vx: 0, vy: BOUNCE_VY }
+let seed = 1
+let maxY = 0
+let cameraY = 0
+let steer: -1 | 0 | 1 = 0
+let raf = 0
+let lastTs = 0
+
+const score = computed(() => Math.max(0, Math.round(maxY * 10)))
+const fallLimit = (1 - BALL_SCREEN) * UNITS_VISIBLE
+
+const reset = () => {
+  seed = (Math.floor(Math.random() * 0xffffffff) || 1) >>> 0
+  const p0 = platformAt(seed, 0)
+  ball = { x: p0.x, y: BALL_RADIUS, vx: 0, vy: BOUNCE_VY }
+  maxY = 0
+  cameraY = 0
+  steer = 0
+}
+
+const gameOver = () => {
+  state.value = 'over'
+  cancelAnimationFrame(raf)
+  raf = 0
+  steer = 0
+  if (score.value > best.value) {
+    best.value = score.value
+    try {
+      localStorage.setItem(BEST_KEY, String(best.value))
+    } catch {
+      // ignore
+    }
+  }
+}
+
+const yToScreen = (worldY: number, H: number, unit: number) =>
+  BALL_SCREEN * H - (worldY - cameraY) * unit
+
+const draw = () => {
+  const canvas = canvasEl.value
+  if (!canvas) return
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  const dpr = window.devicePixelRatio || 1
+  const W = displayW.value
+  const H = displayH.value
+  if (canvas.width !== W * dpr || canvas.height !== H * dpr) {
+    canvas.width = W * dpr
+    canvas.height = H * dpr
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.fillStyle = '#0a0f1e'
+  ctx.fillRect(0, 0, W, H)
+
+  const unit = H / UNITS_VISIBLE
+
+  // Platforms in view
+  const lo = Math.floor((cameraY - (1 - BALL_SCREEN) * UNITS_VISIBLE) / PLATFORM_SPACING) - 1
+  const hi = Math.ceil((cameraY + BALL_SCREEN * UNITS_VISIBLE) / PLATFORM_SPACING) + 1
+  for (let i = Math.max(0, lo); i <= hi; i += 1) {
+    const p = platformAt(seed, i)
+    const sy = yToScreen(p.y, H, unit)
+    if (sy < -20 || sy > H + 20) continue
+    const pw = p.width * W
+    const px = p.x * W - pw / 2
+    ctx.fillStyle = i === 0 ? '#475569' : '#34d399'
+    ctx.fillRect(px, sy - 6, pw, 10)
+    ctx.fillStyle = 'rgba(255,255,255,0.15)'
+    ctx.fillRect(px, sy - 6, pw, 3)
+  }
+
+  // Ball
+  const bx = ball.x * W
+  const by = yToScreen(ball.y, H, unit)
+  ctx.beginPath()
+  ctx.arc(bx, by, BALL_RADIUS * W, 0, Math.PI * 2)
+  ctx.fillStyle = '#f472b6'
+  ctx.shadowColor = '#f472b6'
+  ctx.shadowBlur = 14
+  ctx.fill()
+  ctx.shadowBlur = 0
+}
+
+const tick = (ts: number) => {
+  if (state.value !== 'running') return
+  const dt = lastTs ? Math.min(48, ts - lastTs) : 16
+  lastTs = ts
+
+  const prevY = ball.y
+  ball = stepBall(ball, steer, dt)
+
+  // Bounce off any platform the ball crossed downward this step.
+  if (ball.vy <= 0) {
+    const center = nearestPlatformIndex(ball.y)
+    for (let i = Math.max(0, center - 1); i <= center + 2; i += 1) {
+      const bounced = tryBounce(ball, prevY, platformAt(seed, i))
+      if (bounced) {
+        ball = bounced
+        break
+      }
+    }
+  }
+
+  if (ball.y > maxY) maxY = ball.y
+  cameraY = Math.max(cameraY, ball.y) // camera only rises
+
+  if (ball.y - cameraY < -fallLimit) {
+    draw()
+    gameOver()
+    return
+  }
+  draw()
+  raf = requestAnimationFrame(tick)
+}
+
+const start = () => {
+  reset()
+  state.value = 'running'
+  lastTs = 0
+  cancelAnimationFrame(raf)
+  raf = requestAnimationFrame(tick)
+}
+
+const steerFromX = (clientX: number, el: HTMLElement) => {
+  const rect = el.getBoundingClientRect()
+  steer = clientX - rect.left < rect.width / 2 ? -1 : 1
+}
+
+const onPointerDown = (e: PointerEvent) => {
+  if (state.value !== 'running') {
+    start()
+    return
+  }
+  steerFromX(e.clientX, e.currentTarget as HTMLElement)
+}
+const onPointerMove = (e: PointerEvent) => {
+  if (state.value === 'running' && steer !== 0) steerFromX(e.clientX, e.currentTarget as HTMLElement)
+}
+const stopSteer = () => {
+  steer = 0
+}
+
+const onKeyDown = (e: KeyboardEvent) => {
+  if (e.key === 'ArrowLeft' || e.key === 'a') {
+    e.preventDefault()
+    if (state.value === 'running') steer = -1
+    else start()
+  } else if (e.key === 'ArrowRight' || e.key === 'd') {
+    e.preventDefault()
+    if (state.value === 'running') steer = 1
+    else start()
+  }
+}
+const onKeyUp = (e: KeyboardEvent) => {
+  if (['ArrowLeft', 'ArrowRight', 'a', 'd'].includes(e.key)) steer = 0
+}
+
+watch([displayW, displayH], () => {
+  if (state.value !== 'running') draw()
+})
+
+onMounted(() => {
+  try {
+    best.value = Number(localStorage.getItem(BEST_KEY)) || 0
+  } catch {
+    best.value = 0
+  }
+  reset()
+  draw()
+  window.addEventListener('keydown', onKeyDown)
+  window.addEventListener('keyup', onKeyUp)
+})
+onBeforeUnmount(() => {
+  cancelAnimationFrame(raf)
+  window.removeEventListener('keydown', onKeyDown)
+  window.removeEventListener('keyup', onKeyUp)
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="600">
+    <GameToolbar title="Ball Bounce">
+      <template #intro>
+        The ball bounces on its own — steer <strong>left</strong> and <strong>right</strong> (hold a
+        side, or arrow keys) to land on the next platform. The view only climbs; fall off the bottom
+        and it's over.
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Bounce as high as you can, platform to platform, without dropping off the bottom of the screen.</p>
+        <h3>Controls</h3>
+        <ul>
+          <li>Hold the left or right half of the screen to drift that way (and slide across to keep steering).</li>
+          <li>Desktop: <span class="k">←</span>/<span class="k">→</span> or <span class="k">A</span>/<span class="k">D</span>.</li>
+          <li>The ball wraps around the screen edges.</li>
+        </ul>
+        <h3>Tips</h3>
+        <ul>
+          <li>Line up the next platform while you're rising — you can't change a miss once you're falling past it.</li>
+          <li>Use the wrap: sometimes the quickest path to a platform is off the far edge.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <div class="d-flex align-center mb-3">
+      <div class="text-h6">Height: <span class="font-weight-bold">{{ score }}</span></div>
+      <v-spacer />
+      <div class="text-body-2 text-medium-emphasis">Best: {{ best }}</div>
+    </div>
+
+    <div ref="boardEl" class="stage" :style="{ width: displayW + 'px', height: displayH + 'px' }">
+      <canvas
+        ref="canvasEl"
+        class="canvas"
+        :style="{ width: displayW + 'px', height: displayH + 'px' }"
+        @pointerdown.prevent="onPointerDown"
+        @pointermove="onPointerMove"
+        @pointerup="stopSteer"
+        @pointercancel="stopSteer"
+      />
+      <div v-if="state !== 'running'" class="overlay">
+        <template v-if="state === 'idle'">
+          <p class="text-h6 mb-2">Steer to land the bounces</p>
+          <v-btn color="primary" variant="flat" @click="start">Start</v-btn>
+        </template>
+        <template v-else>
+          <p class="text-h5 mb-1">Dropped!</p>
+          <p class="text-body-2 mb-3">
+            Height {{ score }}<span v-if="score === best && score > 0"> — new best!</span>
+          </p>
+          <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="start">Bounce again</v-btn>
+        </template>
+      </div>
+    </div>
+  </v-container>
+</template>
+
+<style scoped>
+.stage {
+  position: relative;
+  margin: 0 auto;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 0 40px rgba(52, 211, 153, 0.15);
+}
+.canvas {
+  display: block;
+  touch-action: none;
+}
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0 16px;
+  background: rgba(2, 6, 23, 0.7);
+  backdrop-filter: blur(2px);
+}
+</style>

--- a/src/views/ColorMemoryView.vue
+++ b/src/views/ColorMemoryView.vue
@@ -1,0 +1,220 @@
+<script setup lang="ts">
+/**
+ * Color from Memory — a target color flashes for a few seconds, then you
+ * recreate it from memory with R/G/B sliders. Scored by perceptual (redmean)
+ * distance. Logic lives in services/colorMemory.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { randomColor, rating, scorePercent, toCss, type RGB } from '@/services/colorMemory'
+
+const PEEK_SECONDS = 3
+const BEST_KEY = 'colormemory-best'
+
+const phase = ref<'peek' | 'guess' | 'result'>('peek')
+const target = ref<RGB>({ r: 128, g: 128, b: 128 })
+const guess = ref<RGB>({ r: 128, g: 128, b: 128 })
+const countdown = ref(PEEK_SECONDS)
+const round = ref(0)
+const total = ref(0)
+const lastScore = ref(0)
+const best = ref(0)
+
+let peekTimer: ReturnType<typeof setInterval> | null = null
+
+const guessCss = computed(() => toCss(guess.value))
+const targetCss = computed(() => toCss(target.value))
+const average = computed(() => (round.value > 0 ? Math.round(total.value / round.value) : 0))
+
+const stopPeek = () => {
+  if (peekTimer) clearInterval(peekTimer)
+  peekTimer = null
+}
+
+const startRound = () => {
+  stopPeek()
+  target.value = randomColor(Math.random)
+  guess.value = { r: 128, g: 128, b: 128 }
+  phase.value = 'peek'
+  countdown.value = PEEK_SECONDS
+  peekTimer = setInterval(() => {
+    countdown.value -= 1
+    if (countdown.value <= 0) {
+      stopPeek()
+      phase.value = 'guess'
+    }
+  }, 1000)
+}
+
+const submit = () => {
+  if (phase.value !== 'guess') return
+  lastScore.value = scorePercent(target.value, guess.value)
+  total.value += lastScore.value
+  round.value += 1
+  if (lastScore.value > best.value) {
+    best.value = lastScore.value
+    try {
+      localStorage.setItem(BEST_KEY, String(best.value))
+    } catch {
+      // ignore
+    }
+  }
+  phase.value = 'result'
+}
+
+const channels = [
+  { key: 'r', label: 'R', color: '#ef4444' },
+  { key: 'g', label: 'G', color: '#22c55e' },
+  { key: 'b', label: 'B', color: '#3b82f6' },
+] as const
+
+const setChannel = (key: 'r' | 'g' | 'b', v: number) => {
+  guess.value = { ...guess.value, [key]: Math.round(v) }
+}
+
+onMounted(() => {
+  try {
+    best.value = Number(localStorage.getItem(BEST_KEY)) || 0
+  } catch {
+    best.value = 0
+  }
+  startRound()
+})
+onBeforeUnmount(stopPeek)
+</script>
+
+<template>
+  <v-container class="py-6" max-width="520">
+    <GameToolbar title="Color from Memory">
+      <template #intro>
+        A color appears for {{ PEEK_SECONDS }} seconds — study it, then recreate it from memory with
+        the sliders. The closer you get, the higher your score.
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Memorize the target color, then mix it back using the red, green, and blue sliders.</p>
+        <h3>Scoring</h3>
+        <p>Your score (0–100) is based on how close your color looks to the target, using a perceptual color-distance formula — so being a little off in a sensitive channel costs more.</p>
+        <h3>Tips</h3>
+        <ul>
+          <li>Note the hue first (is it warm or cool?), then how light and how vivid it is.</li>
+          <li>Only near-perfect mixes score in the 90s — the scale is deliberately strict.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <!-- Stats -->
+    <div class="d-flex align-center ga-3 mb-4">
+      <div class="text-body-2 text-medium-emphasis">Round {{ round + (phase === 'result' ? 0 : 1) }}</div>
+      <v-spacer />
+      <div class="text-body-2 text-medium-emphasis">Avg: {{ average }}</div>
+      <div class="text-body-2 text-medium-emphasis">Best: {{ best }}</div>
+    </div>
+
+    <!-- Peek -->
+    <template v-if="phase === 'peek'">
+      <div class="swatch swatch--big" :style="{ background: targetCss }">
+        <span class="peek-count">{{ countdown }}</span>
+      </div>
+      <p class="text-center text-medium-emphasis mt-3">Memorize this color…</p>
+    </template>
+
+    <!-- Guess -->
+    <template v-else-if="phase === 'guess'">
+      <div class="swatch swatch--big" :style="{ background: guessCss }" />
+      <div class="mt-4">
+        <div v-for="ch in channels" :key="ch.key" class="channel">
+          <span class="channel-label" :style="{ color: ch.color }">{{ ch.label }}</span>
+          <v-slider
+            :model-value="guess[ch.key]"
+            :min="0"
+            :max="255"
+            :step="1"
+            hide-details
+            density="compact"
+            :color="ch.color"
+            :track-color="ch.color"
+            @update:model-value="(v: number) => setChannel(ch.key, v)"
+          />
+          <span class="channel-value">{{ guess[ch.key] }}</span>
+        </div>
+      </div>
+      <v-btn block color="primary" variant="flat" size="large" class="mt-3" @click="submit">Lock it in</v-btn>
+    </template>
+
+    <!-- Result -->
+    <template v-else>
+      <div class="compare">
+        <div class="compare-col">
+          <div class="swatch" :style="{ background: targetCss }" />
+          <span class="text-caption text-medium-emphasis mt-1">Target</span>
+        </div>
+        <div class="compare-col">
+          <div class="swatch" :style="{ background: guessCss }" />
+          <span class="text-caption text-medium-emphasis mt-1">Yours</span>
+        </div>
+      </div>
+      <div class="text-center mt-4">
+        <p class="text-h3 mb-0">{{ lastScore }}</p>
+        <p class="text-h6 mb-1">{{ rating(lastScore) }}<span v-if="lastScore === best && best > 0"> · new best!</span></p>
+        <p class="text-caption text-medium-emphasis mb-3">
+          Target {{ targetCss }} · Yours {{ guessCss }}
+        </p>
+        <v-btn color="primary" variant="flat" prepend-icon="mdi-arrow-right" @click="startRound">Next color</v-btn>
+      </div>
+    </template>
+  </v-container>
+</template>
+
+<style scoped>
+.swatch {
+  width: 100%;
+  height: 160px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.15);
+}
+.swatch--big {
+  height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.peek-count {
+  font-size: 4rem;
+  font-weight: 800;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
+}
+
+.channel {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.channel-label {
+  width: 18px;
+  font-weight: 800;
+  font-size: 1.1rem;
+}
+.channel-value {
+  width: 34px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.compare {
+  display: flex;
+  gap: 12px;
+}
+.compare-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.compare-col .swatch {
+  height: 140px;
+}
+</style>

--- a/src/views/ColorMemoryView.vue
+++ b/src/views/ColorMemoryView.vue
@@ -25,6 +25,9 @@ let peekTimer: ReturnType<typeof setInterval> | null = null
 const guessCss = computed(() => toCss(guess.value))
 const targetCss = computed(() => toCss(target.value))
 const average = computed(() => (round.value > 0 ? Math.round(total.value / round.value) : 0))
+// The round currently in play: while guessing it's the next one; on the result
+// screen it's the one just scored.
+const currentRound = computed(() => (phase.value === 'result' ? round.value : round.value + 1))
 
 const stopPeek = () => {
   if (peekTimer) clearInterval(peekTimer)
@@ -105,7 +108,7 @@ onBeforeUnmount(stopPeek)
 
     <!-- Stats -->
     <div class="d-flex align-center ga-3 mb-4">
-      <div class="text-body-2 text-medium-emphasis">Round {{ round + (phase === 'result' ? 0 : 1) }}</div>
+      <div class="text-body-2 text-medium-emphasis">Round {{ currentRound }}</div>
       <v-spacer />
       <div class="text-body-2 text-medium-emphasis">Avg: {{ average }}</div>
       <div class="text-body-2 text-medium-emphasis">Best: {{ best }}</div>

--- a/src/views/Connect4View.vue
+++ b/src/views/Connect4View.vue
@@ -1,0 +1,300 @@
+<script setup lang="ts">
+/**
+ * Connect 4 vs AI — drop discs to get four in a row against a negamax bot with
+ * three difficulty levels. You can choose who moves first. Winning discs are
+ * highlighted. AI logic lives in services/connect4.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { useSquareFit } from '@/composables/useSquareFit'
+import {
+  AI,
+  COLS,
+  PLAYER,
+  ROWS,
+  bestMove,
+  dropRow,
+  emptyBoard,
+  findWin,
+  isFull,
+  isWin,
+  play,
+  type Board,
+  type Disc,
+  type Level,
+} from '@/services/connect4'
+
+const { el: boardEl, px: boardPx } = useSquareFit(180)
+const cell = computed(() => boardPx.value / COLS)
+const boardHeight = computed(() => cell.value * ROWS)
+
+const LEVELS: Level[] = ['easy', 'medium', 'hard']
+
+const level = ref<Level>('medium')
+const firstMove = ref<'you' | 'ai'>('you')
+const board = ref<Board>(emptyBoard())
+const turn = ref<'player' | 'ai' | 'over'>('player')
+const winner = ref<Disc | 'draw' | null>(null)
+const winCells = ref<Set<number>>(new Set())
+const hoverCol = ref(-1)
+
+let aiTimer: ReturnType<typeof setTimeout> | null = null
+
+const discAt = (r: number, c: number): Disc => board.value[r * COLS + c]
+const columnFull = (c: number) => dropRow(board.value, c) === -1
+
+const clearAiTimer = () => {
+  if (aiTimer) clearTimeout(aiTimer)
+  aiTimer = null
+}
+
+const finish = (result: Disc | 'draw') => {
+  winner.value = result
+  turn.value = 'over'
+  if (result === PLAYER || result === AI) {
+    winCells.value = new Set(findWin(board.value, result) ?? [])
+  }
+}
+
+const applyMove = (col: number, who: Disc): boolean => {
+  if (columnFull(col)) return false
+  board.value = play(board.value, col, who)
+  if (isWin(board.value, who)) {
+    finish(who)
+    return true
+  }
+  if (isFull(board.value)) {
+    finish('draw')
+    return true
+  }
+  return false
+}
+
+const aiMove = () => {
+  clearAiTimer()
+  aiTimer = setTimeout(() => {
+    if (turn.value !== 'ai') return
+    const col = bestMove(board.value, level.value, Math.random)
+    const done = applyMove(col, AI)
+    if (!done) turn.value = 'player'
+  }, 420)
+}
+
+const drop = (col: number) => {
+  if (turn.value !== 'player' || columnFull(col)) return
+  const done = applyMove(col, PLAYER)
+  if (!done) {
+    turn.value = 'ai'
+    aiMove()
+  }
+}
+
+const newGame = () => {
+  clearAiTimer()
+  board.value = emptyBoard()
+  winner.value = null
+  winCells.value = new Set()
+  hoverCol.value = -1
+  if (firstMove.value === 'ai') {
+    turn.value = 'ai'
+    aiMove()
+  } else {
+    turn.value = 'player'
+  }
+}
+
+const setLevel = (l: Level) => {
+  level.value = l
+  newGame()
+}
+const setFirst = (f: 'you' | 'ai') => {
+  firstMove.value = f
+  newGame()
+}
+
+const statusText = computed(() => {
+  if (winner.value === PLAYER) return 'You win! 🎉'
+  if (winner.value === AI) return 'The AI wins'
+  if (winner.value === 'draw') return "It's a draw"
+  return turn.value === 'ai' ? 'AI is thinking…' : 'Your move'
+})
+
+onMounted(() => {
+  newGame()
+})
+onBeforeUnmount(() => {
+  clearAiTimer()
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="560">
+    <GameToolbar title="Connect 4">
+      <template #intro>
+        Drop your discs and get four in a row — across, down, or diagonally — before the AI does.
+        Pick a difficulty and who goes first.
+      </template>
+      <template #settings>
+        <div class="d-flex flex-column ga-4">
+          <div>
+            <label class="text-caption text-medium-emphasis d-block mb-1">Difficulty</label>
+            <v-btn-toggle :model-value="level" mandatory density="compact" variant="outlined" divided @update:model-value="setLevel">
+              <v-btn v-for="l in LEVELS" :key="l" :value="l" size="small" class="text-capitalize">{{ l }}</v-btn>
+            </v-btn-toggle>
+          </div>
+          <div>
+            <label class="text-caption text-medium-emphasis d-block mb-1">First move</label>
+            <v-btn-toggle :model-value="firstMove" mandatory density="compact" variant="outlined" divided @update:model-value="setFirst">
+              <v-btn value="you" size="small">You</v-btn>
+              <v-btn value="ai" size="small">AI</v-btn>
+            </v-btn-toggle>
+          </div>
+          <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New game</v-btn>
+        </div>
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Be the first to line up four of your discs in a row — horizontally, vertically, or diagonally.</p>
+        <h3>How to play</h3>
+        <ul>
+          <li>Click or tap a column to drop your disc into the lowest open slot.</li>
+          <li>You are <span class="chip chip--you">red</span>; the AI is <span class="chip chip--ai">yellow</span>.</li>
+        </ul>
+        <h3>Difficulty</h3>
+        <p>The AI searches ahead with alpha-beta pruning — 2 moves on easy (with occasional random play), up to 6 on hard.</p>
+      </template>
+    </GameToolbar>
+
+    <!-- Status -->
+    <div class="d-flex align-center mb-3">
+      <div class="text-h6 d-flex align-center ga-2">
+        <span class="dot" :class="turn === 'ai' ? 'dot--ai' : 'dot--you'" />
+        {{ statusText }}
+      </div>
+      <v-spacer />
+      <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New</v-btn>
+    </div>
+
+    <!-- Board -->
+    <div ref="boardEl" class="board-wrap" :style="{ width: boardPx + 'px', height: boardHeight + 'px' }">
+      <div class="board">
+        <div
+          v-for="c in COLS"
+          :key="c"
+          class="col"
+          :class="{ 'col--full': columnFull(c - 1), 'col--hover': hoverCol === c - 1 && turn === 'player' }"
+          @click="drop(c - 1)"
+          @mouseenter="hoverCol = c - 1"
+          @mouseleave="hoverCol = -1"
+        >
+          <div v-for="r in ROWS" :key="r" class="slot">
+            <div
+              class="disc"
+              :class="{
+                'disc--you': discAt(r - 1, c - 1) === PLAYER,
+                'disc--ai': discAt(r - 1, c - 1) === AI,
+                'disc--win': winCells.has((r - 1) * COLS + (c - 1)),
+              }"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div v-if="turn === 'over'" class="overlay">
+        <p class="text-h4 mb-3">{{ statusText }}</p>
+        <v-btn color="primary" variant="flat" prepend-icon="mdi-refresh" @click="newGame">Play again</v-btn>
+      </div>
+    </div>
+  </v-container>
+</template>
+
+<style scoped>
+.board-wrap {
+  position: relative;
+  margin: 0 auto;
+}
+.board {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  gap: 0;
+  padding: 6px;
+  border-radius: 12px;
+  background: linear-gradient(160deg, #1e3a8a, #1e40af);
+  box-shadow: 0 0 40px rgba(37, 99, 235, 0.25), inset 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+.col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+}
+.col--full {
+  cursor: default;
+}
+.col--hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+}
+.slot {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.disc {
+  width: 78%;
+  height: 78%;
+  border-radius: 50%;
+  background: rgba(2, 6, 23, 0.55); /* empty hole */
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.5);
+  transition: background 120ms ease;
+}
+.disc--you {
+  background: radial-gradient(circle at 35% 30%, #f87171, #dc2626);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+.disc--ai {
+  background: radial-gradient(circle at 35% 30%, #fde047, #eab308);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+.disc--win {
+  outline: 3px solid #e2e8f0;
+  outline-offset: -3px;
+  animation: pulse 900ms ease-in-out infinite;
+}
+@keyframes pulse {
+  50% { outline-color: rgba(226, 232, 240, 0.4); }
+}
+
+.dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.dot--you { background: #dc2626; }
+.dot--ai { background: #eab308; }
+
+.chip {
+  padding: 0 6px;
+  border-radius: 4px;
+  font-weight: 700;
+  color: #1a1000;
+}
+.chip--you { background: #f87171; }
+.chip--ai { background: #fde047; }
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: rgba(2, 6, 23, 0.78);
+  backdrop-filter: blur(3px);
+  border-radius: 12px;
+}
+</style>

--- a/src/views/CountBlocksView.vue
+++ b/src/views/CountBlocksView.vue
@@ -1,0 +1,283 @@
+<script setup lang="ts">
+/**
+ * Count the Blocks — a memory game. Tetromino-like shapes stream across the
+ * screen for a few seconds; then you answer how many there were (or, from level
+ * 3, how many of one shape). Each correct answer advances a level (more shapes,
+ * faster, shorter look); one wrong answer ends the run. Round data/difficulty
+ * come from services/countBlocks.
+ */
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { useSquareFit } from '@/composables/useSquareFit'
+import {
+  SHAPE_CELLS,
+  asksTarget,
+  colorOf,
+  correctAnswer,
+  makeRound,
+  type Round,
+} from '@/services/countBlocks'
+
+const { el: boardEl, px: boardPx } = useSquareFit(240)
+
+const BEST_KEY = 'countblocks-best'
+
+const canvasEl = ref<HTMLCanvasElement | null>(null)
+const phase = ref<'watch' | 'answer' | 'result'>('watch')
+const level = ref(1)
+const answer = ref(0)
+const lastCorrect = ref(0)
+const wasRight = ref(false)
+const best = ref(0)
+
+let round: Round = makeRound(1, 'init')
+let seed = 'seed'
+let raf = 0
+let startTs = 0
+
+const targeted = computed(() => asksTarget(level.value))
+const targetColor = computed(() => colorOf(round.target))
+const question = computed(() =>
+  targeted.value ? 'How many of this shape?' : 'How many blocks in total?',
+)
+
+const stopLoop = () => {
+  cancelAnimationFrame(raf)
+  raf = 0
+}
+
+const drawPieces = (t: number) => {
+  const canvas = canvasEl.value
+  if (!canvas) return
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  const dpr = window.devicePixelRatio || 1
+  const W = boardPx.value
+  const H = boardPx.value
+  if (canvas.width !== W * dpr || canvas.height !== H * dpr) {
+    canvas.width = W * dpr
+    canvas.height = H * dpr
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.fillStyle = '#0a0f1e'
+  ctx.fillRect(0, 0, W, H)
+
+  const laneH = H / round.lanes
+  const cell = Math.min(laneH / 2.6, W / 18)
+  const travelDur = round.exposureMs * 0.5
+  const pieceMax = 4 * cell
+
+  for (const p of round.pieces) {
+    const startT = p.startOffset * round.exposureMs * 0.5
+    const local = (t - startT) / travelDur
+    if (local < 0 || local > 1) continue
+    const x = local * (W + pieceMax * 2) - pieceMax
+    const y = p.lane * laneH + laneH / 2 - cell
+    ctx.fillStyle = p.color
+    for (const [cx, cy] of SHAPE_CELLS[p.shape]) {
+      ctx.fillRect(x + cx * cell, y + cy * cell, cell - 2, cell - 2)
+    }
+  }
+}
+
+const loop = (ts: number) => {
+  if (phase.value !== 'watch') return
+  const t = startTs ? ts - startTs : 0
+  if (!startTs) startTs = ts
+  drawPieces(t)
+  if (t >= round.exposureMs) {
+    stopLoop()
+    // Clear the board so the answer isn't given away.
+    const ctx = canvasEl.value?.getContext('2d')
+    if (ctx) {
+      ctx.fillStyle = '#0a0f1e'
+      ctx.fillRect(0, 0, boardPx.value, boardPx.value)
+    }
+    phase.value = 'answer'
+    answer.value = 0
+    return
+  }
+  raf = requestAnimationFrame(loop)
+}
+
+const startWatch = () => {
+  round = makeRound(level.value, seed)
+  phase.value = 'watch'
+  startTs = 0
+  stopLoop()
+  raf = requestAnimationFrame(loop)
+}
+
+const newGame = () => {
+  level.value = 1
+  seed = Math.floor(Math.random() * 0xffffffff).toString(36)
+  startWatch()
+}
+
+const submit = () => {
+  if (phase.value !== 'answer') return
+  lastCorrect.value = correctAnswer(round)
+  wasRight.value = answer.value === lastCorrect.value
+  phase.value = 'result'
+  if (wasRight.value) {
+    if (level.value > best.value) {
+      best.value = level.value
+      try {
+        localStorage.setItem(BEST_KEY, String(best.value))
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+const next = () => {
+  level.value += 1
+  startWatch()
+}
+
+const adjust = (delta: number) => {
+  answer.value = Math.max(0, Math.min(40, answer.value + delta))
+}
+
+watch(boardPx, () => {
+  if (phase.value === 'watch') drawPieces(startTs ? performance.now() - startTs : 0)
+})
+
+onMounted(() => {
+  try {
+    best.value = Number(localStorage.getItem(BEST_KEY)) || 0
+  } catch {
+    best.value = 0
+  }
+  newGame()
+})
+onBeforeUnmount(stopLoop)
+</script>
+
+<template>
+  <v-container class="py-6" max-width="560">
+    <GameToolbar title="Count the Blocks">
+      <template #intro>
+        Watch the shapes slide past, then answer how many there were. From level 3 you'll be asked
+        how many of <em>one</em> shape. Get it right to level up — it gets faster and busier.
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Keep a running count of the blocks streaming across the screen, then enter it. Each correct answer advances a level; one miss ends the run.</p>
+        <h3>How it works</h3>
+        <ul>
+          <li>Early levels: count <em>all</em> the shapes.</li>
+          <li>Level 3+: count only the shapes matching the one shown in the question.</li>
+          <li>Higher levels add more shapes, move faster, and give you less time.</li>
+        </ul>
+        <h3>Tips</h3>
+        <ul>
+          <li>Scan lane by lane rather than chasing individual shapes.</li>
+          <li>For the targeted question, lock onto the color and ignore the rest.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <div class="d-flex align-center mb-3">
+      <div class="text-h6">Level <span class="font-weight-bold">{{ level }}</span></div>
+      <v-spacer />
+      <div class="text-body-2 text-medium-emphasis">Best level: {{ best }}</div>
+    </div>
+
+    <div ref="boardEl" class="stage" :style="{ width: boardPx + 'px', height: boardPx + 'px' }">
+      <canvas ref="canvasEl" class="canvas" :style="{ width: boardPx + 'px', height: boardPx + 'px' }" />
+
+      <div v-if="phase === 'watch'" class="banner">Watch closely…</div>
+
+      <div v-else class="overlay">
+        <template v-if="phase === 'answer'">
+          <p class="text-h6 mb-1 d-flex align-center ga-2">
+            {{ question }}
+            <svg v-if="targeted" width="34" height="24" viewBox="0 0 4 2" class="shape-icon">
+              <rect
+                v-for="([cx, cy], i) in SHAPE_CELLS[round.target]"
+                :key="i"
+                :x="cx"
+                :y="cy"
+                width="0.92"
+                height="0.92"
+                :fill="targetColor"
+              />
+            </svg>
+          </p>
+          <div class="stepper my-3">
+            <v-btn icon="mdi-minus" size="large" variant="tonal" @click="adjust(-1)" />
+            <span class="answer-num">{{ answer }}</span>
+            <v-btn icon="mdi-plus" size="large" variant="tonal" @click="adjust(1)" />
+          </div>
+          <v-btn color="primary" variant="flat" size="large" @click="submit">Submit</v-btn>
+        </template>
+
+        <template v-else>
+          <p class="text-h4 mb-1">{{ wasRight ? 'Correct! 🎉' : 'Wrong' }}</p>
+          <p class="text-body-1 mb-4">
+            It was <strong>{{ lastCorrect }}</strong><span v-if="!wasRight"> — you said {{ answer }}</span>.
+          </p>
+          <v-btn v-if="wasRight" color="primary" variant="flat" prepend-icon="mdi-arrow-right" @click="next">
+            Level {{ level + 1 }}
+          </v-btn>
+          <v-btn v-else color="primary" variant="flat" prepend-icon="mdi-restart" @click="newGame">
+            Play again (reached level {{ level }})
+          </v-btn>
+        </template>
+      </div>
+    </div>
+  </v-container>
+</template>
+
+<style scoped>
+.stage {
+  position: relative;
+  margin: 0 auto;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 0 40px rgba(168, 85, 247, 0.15);
+}
+.canvas {
+  display: block;
+}
+.banner {
+  position: absolute;
+  top: 10px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.8);
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+}
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0 16px;
+  background: rgba(2, 6, 23, 0.82);
+  backdrop-filter: blur(3px);
+}
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+.answer-num {
+  font-size: 3rem;
+  font-weight: 800;
+  min-width: 70px;
+  font-variant-numeric: tabular-nums;
+}
+.shape-icon {
+  overflow: visible;
+}
+</style>

--- a/src/views/CountBlocksView.vue
+++ b/src/views/CountBlocksView.vue
@@ -141,7 +141,9 @@ const adjust = (delta: number) => {
 }
 
 watch(boardPx, () => {
+  // Redraw at the current elapsed time; before the first frame startTs is 0.
   if (phase.value === 'watch') drawPieces(startTs ? performance.now() - startTs : 0)
+  else drawPieces(round.exposureMs) // answer/result: keep the board cleared
 })
 
 onMounted(() => {

--- a/src/views/Game2048View.vue
+++ b/src/views/Game2048View.vue
@@ -1,0 +1,385 @@
+<script setup lang="ts">
+/**
+ * 2048 — slide tiles with arrows / WASD / swipe / d-pad; equal tiles merge.
+ * Reach 2048 to win, then keep going for a high score. One-level undo and a
+ * best score persisted in localStorage. Movement animates by transitioning each
+ * tile's position; merges and spawns pop. Core logic lives in services/game2048.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { copyToClipboard } from '@/services/share'
+import { useSquareFit } from '@/composables/useSquareFit'
+import { SIZE, canMove, hasWon, move, spawn, type Direction, type Tile } from '@/services/game2048'
+
+const { el: boardEl, px: boardPx } = useSquareFit(150)
+
+const GAP = 10 // px between cells (scaled implicitly by the fitted board size)
+const BEST_KEY = '2048-best'
+
+const tiles = ref<Tile[]>([])
+const consumed = ref<Tile[]>([]) // merged-away tiles kept one frame so they can slide in
+const score = ref(0)
+const best = ref(0)
+const won = ref(false)
+const keepPlaying = ref(false)
+const over = ref(false)
+
+let nextId = 1
+let undo: { tiles: Tile[]; score: number } | null = null
+const canUndo = ref(false)
+let cleanupTimer: ReturnType<typeof setTimeout> | null = null
+let busy = false // ignore input mid-animation so rapid keys can't desync the board
+
+// Cell geometry derived from the fitted board so tiles line up with the grid.
+const cellSize = computed(() => (boardPx.value - GAP * (SIZE + 1)) / SIZE)
+const offset = (i: number) => GAP + i * (cellSize.value + GAP)
+
+const renderTiles = computed(() => [...consumed.value, ...tiles.value])
+
+const tileStyle = (t: Tile) => ({
+  width: `${cellSize.value}px`,
+  height: `${cellSize.value}px`,
+  transform: `translate(${offset(t.col)}px, ${offset(t.row)}px)`,
+})
+
+// Larger numbers get smaller text so they still fit the tile.
+const tileFontSize = (value: number) => {
+  const digits = String(value).length
+  const scale = digits >= 4 ? 0.34 : digits === 3 ? 0.42 : 0.5
+  return `${Math.max(14, cellSize.value * scale)}px`
+}
+
+const persistBest = () => {
+  if (score.value > best.value) {
+    best.value = score.value
+    try {
+      localStorage.setItem(BEST_KEY, String(best.value))
+    } catch {
+      // ignore storage errors (private mode / quota)
+    }
+  }
+}
+
+const newGame = () => {
+  if (cleanupTimer) clearTimeout(cleanupTimer)
+  tiles.value = []
+  consumed.value = []
+  score.value = 0
+  won.value = false
+  keepPlaying.value = false
+  over.value = false
+  undo = null
+  canUndo.value = false
+  busy = false
+  addRandomTile()
+  addRandomTile()
+}
+
+const addRandomTile = () => {
+  const t = spawn(tiles.value, Math.random, (nextId += 1))
+  if (t) tiles.value = [...tiles.value, t]
+}
+
+const doMove = (dir: Direction) => {
+  if (busy || over.value) return
+  const before = tiles.value
+  const result = move(before, dir)
+  if (!result.moved) return
+
+  // Snapshot for undo (deep copy so later mutations don't leak in).
+  undo = { tiles: before.map((t) => ({ ...t, isNew: false, merged: false })), score: score.value }
+  canUndo.value = true
+
+  score.value += result.gained
+  consumed.value = result.consumed
+  tiles.value = result.tiles
+  busy = true
+
+  // After the slide settles, drop consumed tiles, then spawn the new one.
+  cleanupTimer = setTimeout(() => {
+    consumed.value = []
+    tiles.value = tiles.value.map((t) => ({ ...t, merged: false }))
+    addRandomTile()
+    if (!won.value && hasWon(tiles.value)) won.value = true
+    if (!canMove(tiles.value)) {
+      over.value = true
+      persistBest()
+    }
+    busy = false
+  }, 110)
+}
+
+const undoMove = () => {
+  if (!undo || busy) return
+  if (cleanupTimer) clearTimeout(cleanupTimer)
+  tiles.value = undo.tiles
+  score.value = undo.score
+  consumed.value = []
+  over.value = false
+  undo = null
+  canUndo.value = false
+  busy = false
+}
+
+const continueAfterWin = () => {
+  keepPlaying.value = true
+}
+
+const KEY_DIRS: Record<string, Direction> = {
+  ArrowUp: 'up', w: 'up', W: 'up',
+  ArrowDown: 'down', s: 'down', S: 'down',
+  ArrowLeft: 'left', a: 'left', A: 'left',
+  ArrowRight: 'right', d: 'right', D: 'right',
+}
+
+const onKey = (e: KeyboardEvent) => {
+  const dir = KEY_DIRS[e.key]
+  if (dir) {
+    e.preventDefault()
+    doMove(dir)
+  }
+}
+
+// Swipe support
+let touchStart: { x: number; y: number } | null = null
+const onTouchStart = (e: TouchEvent) => {
+  const t = e.changedTouches[0]
+  touchStart = { x: t.clientX, y: t.clientY }
+}
+const onTouchEnd = (e: TouchEvent) => {
+  if (!touchStart) return
+  const t = e.changedTouches[0]
+  const dx = t.clientX - touchStart.x
+  const dy = t.clientY - touchStart.y
+  touchStart = null
+  if (Math.abs(dx) < 24 && Math.abs(dy) < 24) return
+  if (Math.abs(dx) > Math.abs(dy)) doMove(dx > 0 ? 'right' : 'left')
+  else doMove(dy > 0 ? 'down' : 'up')
+}
+
+const snackbar = ref(false)
+const share = async () => {
+  const url = window.location.origin + '/2048'
+  await copyToClipboard(`I scored ${score.value} in 2048${score.value === best.value && score.value > 0 ? ' (my best!)' : ''}. Beat me!\n${url}`)
+  snackbar.value = true
+}
+
+onMounted(() => {
+  try {
+    best.value = Number(localStorage.getItem(BEST_KEY)) || 0
+  } catch {
+    best.value = 0
+  }
+  newGame()
+  window.addEventListener('keydown', onKey)
+})
+onBeforeUnmount(() => {
+  if (cleanupTimer) clearTimeout(cleanupTimer)
+  window.removeEventListener('keydown', onKey)
+})
+
+const showWinOverlay = computed(() => won.value && !keepPlaying.value && !over.value)
+</script>
+
+<template>
+  <v-container class="py-6" max-width="620">
+    <GameToolbar title="2048" shareable @share="share">
+      <template #intro>
+        Arrow keys / WASD, the d-pad, or swipe. Slide the tiles — equal numbers merge. Reach
+        <strong>2048</strong> to win, then keep going for a high score.
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Combine tiles until one reads 2048. You can keep playing afterward to push your score higher.</p>
+        <h3>Controls</h3>
+        <ul>
+          <li><span class="k">Arrow keys</span> or <span class="k">WASD</span> on desktop.</li>
+          <li>The on-screen <span class="k">d-pad</span> or a <span class="k">swipe</span> on mobile.</li>
+        </ul>
+        <h3>Rules</h3>
+        <ul>
+          <li>Every move slides all tiles as far as they'll go in that direction.</li>
+          <li>Two tiles of the same number merge into one worth their sum — but each tile merges at most once per move.</li>
+          <li>A new 2 or 4 appears after every move. It's game over when no move is possible.</li>
+        </ul>
+        <h3>Tips</h3>
+        <ul>
+          <li>Keep your biggest tile pinned in a corner and build a descending row toward it.</li>
+          <li>Pick one direction you never press unless forced — it keeps your board tidy.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <!-- Scoreboard -->
+    <div class="d-flex align-center ga-3 mb-3">
+      <div class="score-box">
+        <div class="score-label">Score</div>
+        <div class="score-value">{{ score }}</div>
+      </div>
+      <div class="score-box">
+        <div class="score-label">Best</div>
+        <div class="score-value">{{ best }}</div>
+      </div>
+      <v-spacer />
+      <v-btn variant="text" :disabled="!canUndo" prepend-icon="mdi-undo" @click="undoMove">Undo</v-btn>
+      <v-btn variant="tonal" color="primary" prepend-icon="mdi-restart" @click="newGame">New</v-btn>
+    </div>
+
+    <!-- Board -->
+    <div
+      ref="boardEl"
+      class="board"
+      :style="{ width: boardPx + 'px', height: boardPx + 'px', padding: GAP + 'px', gap: GAP + 'px', gridTemplateColumns: `repeat(${SIZE}, 1fr)` }"
+      @touchstart.passive="onTouchStart"
+      @touchend="onTouchEnd"
+    >
+      <!-- Background cells -->
+      <div v-for="i in SIZE * SIZE" :key="i" class="cell" />
+
+      <!-- Tiles (absolutely positioned, transitioned) -->
+      <div
+        v-for="t in renderTiles"
+        :key="t.id"
+        class="tile"
+        :class="[`tile--${t.value <= 2048 ? t.value : 'super'}`, { 'tile--new': t.isNew, 'tile--merged': t.merged }]"
+        :style="[tileStyle(t), { fontSize: tileFontSize(t.value) }]"
+      >
+        {{ t.value }}
+      </div>
+
+      <!-- Overlays -->
+      <div v-if="showWinOverlay" class="overlay">
+        <p class="text-h4 mb-1">You win! 🎉</p>
+        <p class="text-body-1 mb-4">Reached 2048 with a score of {{ score }}.</p>
+        <div class="d-flex ga-2">
+          <v-btn color="primary" variant="flat" @click="continueAfterWin">Keep going</v-btn>
+          <v-btn variant="tonal" prepend-icon="mdi-restart" @click="newGame">New game</v-btn>
+        </div>
+      </div>
+      <div v-else-if="over" class="overlay">
+        <p class="text-h4 mb-1">Game over</p>
+        <p class="text-body-1 mb-4">
+          Score {{ score }}<span v-if="score === best && score > 0"> — new best!</span>
+        </p>
+        <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="newGame">Play again</v-btn>
+      </div>
+    </div>
+
+    <!-- On-screen d-pad -->
+    <div class="dpad mt-5">
+      <v-btn icon="mdi-chevron-up" variant="tonal" class="dpad--up" @click="doMove('up')" />
+      <v-btn icon="mdi-chevron-left" variant="tonal" class="dpad--left" @click="doMove('left')" />
+      <v-btn icon="mdi-chevron-right" variant="tonal" class="dpad--right" @click="doMove('right')" />
+      <v-btn icon="mdi-chevron-down" variant="tonal" class="dpad--down" @click="doMove('down')" />
+    </div>
+
+    <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Score copied — challenge a friend!</v-snackbar>
+  </v-container>
+</template>
+
+<style scoped>
+.board {
+  position: relative;
+  display: grid;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  box-shadow: 0 0 40px rgba(124, 58, 237, 0.18), inset 0 0 40px rgba(124, 58, 237, 0.06);
+  touch-action: none;
+  user-select: none;
+}
+
+.cell {
+  border-radius: 8px;
+  background: rgba(148, 163, 184, 0.06);
+}
+
+.tile {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-weight: 800;
+  color: #f8fafc;
+  /* Transition position only; the pop is a separate keyframe so it never fights the slide. */
+  transition: transform 105ms ease-in-out;
+  will-change: transform;
+}
+
+.tile--new {
+  animation: pop-in 130ms ease-out;
+}
+.tile--merged {
+  animation: pop-merge 130ms ease-out;
+}
+
+@keyframes pop-in {
+  0% { opacity: 0; }
+  60% { opacity: 1; }
+}
+@keyframes pop-merge {
+  0% { transform: var(--merge-from, none); }
+  50% { scale: 1.12; }
+  100% { scale: 1; }
+}
+
+/* Tile palette — climbs from cool to warm as values grow. */
+.tile--2 { background: #334155; }
+.tile--4 { background: #3f4b63; }
+.tile--8 { background: #2563eb; }
+.tile--16 { background: #4f46e5; }
+.tile--32 { background: #7c3aed; }
+.tile--64 { background: #9333ea; }
+.tile--128 { background: #c026d3; }
+.tile--256 { background: #db2777; }
+.tile--512 { background: #e11d48; }
+.tile--1024 { background: #f97316; }
+.tile--2048 { background: #facc15; color: #2b1a00; box-shadow: 0 0 24px rgba(250, 204, 21, 0.65); }
+.tile--super { background: #34d399; color: #032311; box-shadow: 0 0 24px rgba(52, 211, 153, 0.6); }
+
+.score-box {
+  background: rgba(30, 41, 59, 0.75);
+  border-radius: 8px;
+  padding: 4px 16px;
+  min-width: 84px;
+  text-align: center;
+}
+.score-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.9);
+}
+.score-value {
+  font-size: 1.4rem;
+  font-weight: 800;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: rgba(2, 6, 23, 0.78);
+  backdrop-filter: blur(3px);
+  border-radius: 12px;
+}
+
+.dpad {
+  display: grid;
+  grid-template-columns: repeat(3, 48px);
+  grid-template-rows: repeat(2, 48px);
+  gap: 6px;
+  justify-content: center;
+}
+.dpad--up { grid-area: 1 / 2; }
+.dpad--left { grid-area: 2 / 1; }
+.dpad--down { grid-area: 2 / 2; }
+.dpad--right { grid-area: 2 / 3; }
+</style>

--- a/src/views/Game2048View.vue
+++ b/src/views/Game2048View.vue
@@ -81,7 +81,7 @@ const addRandomTile = () => {
 }
 
 const doMove = (dir: Direction) => {
-  if (busy || over.value) return
+  if (busy || over.value || showWinOverlay.value) return
   const before = tiles.value
   const result = move(before, dir)
   if (!result.moved) return
@@ -101,10 +101,8 @@ const doMove = (dir: Direction) => {
     tiles.value = tiles.value.map((t) => ({ ...t, merged: false }))
     addRandomTile()
     if (!won.value && hasWon(tiles.value)) won.value = true
-    if (!canMove(tiles.value)) {
-      over.value = true
-      persistBest()
-    }
+    if (!canMove(tiles.value)) over.value = true
+    persistBest() // keep the stored best current after every move, not only at game over
     busy = false
   }, 110)
 }
@@ -116,6 +114,7 @@ const undoMove = () => {
   score.value = undo.score
   consumed.value = []
   over.value = false
+  won.value = hasWon(undo.tiles) // undoing the winning move drops win state too
   undo = null
   canUndo.value = false
   busy = false
@@ -175,6 +174,7 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   if (cleanupTimer) clearTimeout(cleanupTimer)
+  persistBest() // don't lose a running best if the player leaves mid-game
   window.removeEventListener('keydown', onKey)
 })
 
@@ -309,20 +309,22 @@ const showWinOverlay = computed(() => won.value && !keepPlaying.value && !over.v
   will-change: transform;
 }
 
+/* Pops animate the `scale` property, NOT `transform` — `transform` carries each
+   tile's grid position, so animating it here would fling the tile from (0,0). */
 .tile--new {
-  animation: pop-in 130ms ease-out;
+  animation: pop-in 100ms ease-out;
 }
 .tile--merged {
-  animation: pop-merge 130ms ease-out;
+  animation: pop-merge 100ms ease-out;
 }
 
 @keyframes pop-in {
-  0% { opacity: 0; }
-  60% { opacity: 1; }
+  0% { opacity: 0; scale: 0.6; }
+  100% { opacity: 1; scale: 1; }
 }
 @keyframes pop-merge {
-  0% { transform: var(--merge-from, none); }
-  50% { scale: 1.12; }
+  0% { scale: 1; }
+  50% { scale: 1.14; }
   100% { scale: 1; }
 }
 

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -102,6 +102,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(56, 189, 248, 0.34), rgba(239, 68, 68, 0.32))',
   },
   {
+    key: 'ball-bounce',
+    title: 'Ball Bounce',
+    description:
+      'A doodle-jump climber: the ball bounces on its own, you steer left/right to land the next platform. The screen only rises — don’t drop off.',
+    icon: 'mdi-circle-outline',
+    to: '/ball-bounce',
+    gradient: 'linear-gradient(135deg, rgba(52, 211, 153, 0.34), rgba(244, 114, 182, 0.3))',
+  },
+  {
     key: 'snake',
     title: 'Snake',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -165,6 +165,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(142, 36, 170, 0.42), rgba(15, 23, 42, 0.35))',
   },
   {
+    key: 'color-memory',
+    title: 'Color from Memory',
+    description:
+      'A color flashes for a few seconds — then recreate it from memory with RGB sliders. Scored on how close it looks, not just the numbers.',
+    icon: 'mdi-palette-outline',
+    to: '/color-memory',
+    gradient: 'linear-gradient(135deg, hsl(330, 80%, 55%), hsl(190, 80%, 50%), hsl(50, 90%, 55%))',
+  },
+  {
     key: 'time-since',
     title: 'Time Since',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -93,6 +93,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(142, 36, 170, 0.42), rgba(251, 191, 36, 0.24))',
   },
   {
+    key: 'sudoku',
+    title: 'Sudoku',
+    description:
+      'The classic 1–9 logic puzzle, in four difficulties. Pencil notes, conflict highlighting, hints, and a fresh guaranteed-unique board every time.',
+    icon: 'mdi-grid-large',
+    to: '/sudoku',
+    gradient: 'linear-gradient(135deg, rgba(59, 130, 246, 0.36), rgba(148, 163, 184, 0.18))',
+  },
+  {
     key: 'flood-it',
     title: 'Flood It',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -75,6 +75,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(34, 211, 238, 0.32), rgba(168, 85, 247, 0.30))',
   },
   {
+    key: 'memory',
+    title: 'Memory',
+    description:
+      'Two quick memory games in one: flip cards to find the pairs, or watch a growing color sequence and repeat it back (Simon).',
+    icon: 'mdi-cards-outline',
+    to: '/memory',
+    gradient: 'linear-gradient(135deg, rgba(52, 211, 153, 0.32), rgba(59, 130, 246, 0.3))',
+  },
+  {
     key: 'snake',
     title: 'Snake',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -102,6 +102,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(59, 130, 246, 0.36), rgba(148, 163, 184, 0.18))',
   },
   {
+    key: 'nonogram',
+    title: 'Nonogram',
+    description:
+      'Reveal a hidden pixel picture by filling cells that satisfy the row and column number clues. Drag to paint, X-mark the gaps, three sizes.',
+    icon: 'mdi-dots-grid',
+    to: '/nonogram',
+    gradient: 'linear-gradient(135deg, rgba(124, 58, 237, 0.4), rgba(15, 23, 42, 0.3))',
+  },
+  {
     key: 'flood-it',
     title: 'Flood It',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -57,6 +57,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(249, 115, 22, 0.42), rgba(250, 204, 21, 0.24))',
   },
   {
+    key: 'tetris',
+    title: 'Tetris',
+    description:
+      'The falling-blocks classic: rotate and stack tetrominoes to clear lines. Ghost piece, hold slot, next queue, and rising speed.',
+    icon: 'mdi-view-quilt-outline',
+    to: '/tetris',
+    gradient: 'linear-gradient(135deg, rgba(34, 211, 238, 0.32), rgba(168, 85, 247, 0.30))',
+  },
+  {
     key: 'snake',
     title: 'Snake',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -48,15 +48,6 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, hsl(0, 70%, 55%), hsl(140, 68%, 48%), hsl(255, 70%, 58%))',
   },
   {
-    key: 'nerdle',
-    title: 'Nerdle',
-    description:
-      'Wordle for math: guess the hidden 8-tile equation in six tries. Tiles reveal which digits and operators are right, and where.',
-    icon: 'mdi-calculator-variant-outline',
-    to: '/nerdle',
-    gradient: 'linear-gradient(135deg, rgba(34, 197, 94, 0.34), rgba(168, 85, 247, 0.30))',
-  },
-  {
     key: '2048',
     title: '2048',
     description:
@@ -217,6 +208,15 @@ const games: GameCard[] = [
     icon: 'mdi-golf',
     to: '/mini-golf',
     gradient: 'linear-gradient(135deg, rgba(22, 101, 52, 0.5), rgba(52, 211, 153, 0.3))',
+  },
+  {
+    key: 'nerdle',
+    title: 'Nerdle',
+    description:
+      'Wordle for math: guess the hidden 8-tile equation in six tries. Tiles reveal which digits and operators are right, and where.',
+    icon: 'mdi-calculator-variant-outline',
+    to: '/nerdle',
+    gradient: 'linear-gradient(135deg, rgba(34, 197, 94, 0.34), rgba(168, 85, 247, 0.30))',
   },
   {
     key: 'time-since',

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -48,6 +48,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, hsl(0, 70%, 55%), hsl(140, 68%, 48%), hsl(255, 70%, 58%))',
   },
   {
+    key: '2048',
+    title: '2048',
+    description:
+      'Slide and merge numbered tiles to reach 2048 — then keep going. Swipe or arrow keys, one-level undo, and a saved best score.',
+    icon: 'mdi-numeric',
+    to: '/2048',
+    gradient: 'linear-gradient(135deg, rgba(249, 115, 22, 0.42), rgba(250, 204, 21, 0.24))',
+  },
+  {
     key: 'snake',
     title: 'Snake',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -84,6 +84,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(52, 211, 153, 0.32), rgba(59, 130, 246, 0.3))',
   },
   {
+    key: 'tunnel',
+    title: 'Vertical Tunnel',
+    description:
+      'Fly up an endless, narrowing tunnel — tap the left or right side to flap that way, and don’t drift into the walls. It speeds up as you climb.',
+    icon: 'mdi-airplane',
+    to: '/tunnel',
+    gradient: 'linear-gradient(135deg, rgba(56, 189, 248, 0.38), rgba(244, 114, 182, 0.3))',
+  },
+  {
     key: 'snake',
     title: 'Snake',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -93,6 +93,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(56, 189, 248, 0.38), rgba(244, 114, 182, 0.3))',
   },
   {
+    key: 'ninja-climb',
+    title: 'Ninja Climb',
+    description:
+      'Cling to a wall, hold to charge, and leap to the other side — longer holds jump higher. Dodge spikes and outclimb the rising lava.',
+    icon: 'mdi-ninja',
+    to: '/ninja-climb',
+    gradient: 'linear-gradient(135deg, rgba(56, 189, 248, 0.34), rgba(239, 68, 68, 0.32))',
+  },
+  {
     key: 'snake',
     title: 'Snake',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -192,6 +192,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(142, 36, 170, 0.42), rgba(15, 23, 42, 0.35))',
   },
   {
+    key: 'count-blocks',
+    title: 'Count the Blocks',
+    description:
+      'Tetromino shapes stream past for a few seconds — then say how many there were (or how many of one shape). Each right answer levels you up.',
+    icon: 'mdi-counter',
+    to: '/count-blocks',
+    gradient: 'linear-gradient(135deg, rgba(168, 85, 247, 0.36), rgba(34, 211, 238, 0.28))',
+  },
+  {
     key: 'color-memory',
     title: 'Color from Memory',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -48,6 +48,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, hsl(0, 70%, 55%), hsl(140, 68%, 48%), hsl(255, 70%, 58%))',
   },
   {
+    key: 'nerdle',
+    title: 'Nerdle',
+    description:
+      'Wordle for math: guess the hidden 8-tile equation in six tries. Tiles reveal which digits and operators are right, and where.',
+    icon: 'mdi-calculator-variant-outline',
+    to: '/nerdle',
+    gradient: 'linear-gradient(135deg, rgba(34, 197, 94, 0.34), rgba(168, 85, 247, 0.30))',
+  },
+  {
     key: '2048',
     title: '2048',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -210,6 +210,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, hsl(330, 80%, 55%), hsl(190, 80%, 50%), hsl(50, 90%, 55%))',
   },
   {
+    key: 'mini-golf',
+    title: 'Mini Golf',
+    description:
+      'Nine seeded holes. Pull back to aim and set power, then putt — bank off the walls and sink it in as few strokes as you can.',
+    icon: 'mdi-golf',
+    to: '/mini-golf',
+    gradient: 'linear-gradient(135deg, rgba(22, 101, 52, 0.5), rgba(52, 211, 153, 0.3))',
+  },
+  {
     key: 'time-since',
     title: 'Time Since',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -111,6 +111,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(124, 58, 237, 0.4), rgba(15, 23, 42, 0.3))',
   },
   {
+    key: 'tango',
+    title: 'Tango',
+    description:
+      'Fill a 6×6 grid with Suns and Moons: balance every row and column, no three in a row, and honor the =/× links. Pure logic, always solvable.',
+    icon: 'mdi-weather-sunny',
+    to: '/tango',
+    gradient: 'linear-gradient(135deg, rgba(250, 204, 21, 0.34), rgba(129, 140, 248, 0.30))',
+  },
+  {
     key: 'flood-it',
     title: 'Flood It',
     description:

--- a/src/views/GamesView.vue
+++ b/src/views/GamesView.vue
@@ -147,6 +147,15 @@ const games: GameCard[] = [
     gradient: 'linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(34, 197, 94, 0.28))',
   },
   {
+    key: 'connect-4',
+    title: 'Connect 4',
+    description:
+      'Drop discs to line up four in a row against a negamax AI with alpha-beta pruning. Three difficulties and you choose who starts.',
+    icon: 'mdi-circle-multiple-outline',
+    to: '/connect-4',
+    gradient: 'linear-gradient(135deg, rgba(37, 99, 235, 0.4), rgba(234, 179, 8, 0.28))',
+  },
+  {
     key: 'wizard-chess',
     title: 'Wizard Chess',
     description:

--- a/src/views/MemoryView.vue
+++ b/src/views/MemoryView.vue
@@ -8,21 +8,35 @@
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import GameToolbar from '@/components/GameToolbar.vue'
 import {
-  SIMON_PADS,
+  DIFFICULTIES,
+  DIFFICULTY_ORDER,
+  type Difficulty,
   buildDeck,
   checkSimon,
   extendSequence,
   isMatch,
   matchStars,
+  padsFor,
+  pairsFor,
 } from '@/services/memory'
+import { SimonAudio } from '@/services/memoryAudio'
 
 const FACES = ['🍎', '🌟', '🎈', '🐱', '🌸', '⚡', '🍕', '🎸', '🚀', '🎲', '🍩', '👾']
+// Colors + labels for pad 0..MAX_SIMON_PADS-1 (harder difficulties use more).
+const PAD_LABELS = ['green', 'red', 'yellow', 'blue', 'purple', 'cyan']
 const SIMON_BEST_KEY = 'simon-best'
 
 const mode = ref<'match' | 'simon'>('match')
 
+// --- Difficulty / size --------------------------------------------------
+// One preset drives both modes: Match pairs and the number of Simon pads.
+const difficulty = ref<Difficulty>('medium')
+const difficultyLabels: Record<Difficulty, string> = { easy: 'Easy', medium: 'Medium', hard: 'Hard' }
+const pairs = computed(() => pairsFor(difficulty.value))
+const pads = computed(() => padsFor(difficulty.value))
+const simonCols = computed(() => (pads.value <= 4 ? 2 : 3))
+
 // --- Match --------------------------------------------------------------
-const pairs = ref(8)
 const deck = ref<number[]>([])
 const flipped = ref<number[]>([])
 const matched = ref<Set<number>>(new Set())
@@ -70,6 +84,15 @@ const simonState = ref<'idle' | 'show' | 'input' | 'over'>('idle')
 const activePad = ref(-1)
 const simonBest = ref(0)
 
+// Web Audio tones — one per pad. Guarded so tests/SSR (no AudioContext) no-op.
+const audio = new SimonAudio()
+const muted = ref(false)
+const audioAvailable = audio.available
+const toggleMute = () => {
+  muted.value = !muted.value
+  audio.muted = muted.value
+}
+
 const simonLevel = computed(() => sequence.value.length)
 
 let timers: ReturnType<typeof setTimeout>[] = []
@@ -90,6 +113,7 @@ const playSequence = () => {
       return
     }
     activePad.value = sequence.value[i]
+    audio.play(activePad.value, 420)
     pushTimer(
       setTimeout(() => {
         activePad.value = -1
@@ -114,8 +138,9 @@ const persistSimonBest = () => {
 }
 
 const startSimon = () => {
+  audio.resume() // first gesture — unlock/resume the AudioContext
   clearTimers()
-  sequence.value = extendSequence([], Math.random)
+  sequence.value = extendSequence([], Math.random, pads.value)
   simonInput.value = []
   simonState.value = 'show'
   playSequence()
@@ -132,6 +157,8 @@ const flashPad = (p: number) => {
 
 const tapPad = (p: number) => {
   if (simonState.value !== 'input') return
+  audio.resume() // keep the context alive; safe to call repeatedly
+  audio.play(p, 220)
   flashPad(p)
   simonInput.value = [...simonInput.value, p]
   const result = checkSimon(sequence.value, simonInput.value)
@@ -143,7 +170,7 @@ const tapPad = (p: number) => {
     simonState.value = 'show'
     pushTimer(
       setTimeout(() => {
-        sequence.value = extendSequence(sequence.value, Math.random)
+        sequence.value = extendSequence(sequence.value, Math.random, pads.value)
         playSequence()
       }, 650),
     )
@@ -165,6 +192,20 @@ const newGame = () => {
   else startSimon()
 }
 
+// Changing size starts a fresh game at the new size in whichever mode is active.
+const setDifficulty = (d: Difficulty) => {
+  difficulty.value = d
+  clearTimers()
+  if (mode.value === 'match') {
+    buildMatch()
+  } else {
+    simonState.value = 'idle'
+    activePad.value = -1
+    sequence.value = []
+    simonInput.value = []
+  }
+}
+
 onMounted(() => {
   try {
     simonBest.value = Number(localStorage.getItem(SIMON_BEST_KEY)) || 0
@@ -175,6 +216,7 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   clearTimers()
+  audio.dispose()
 })
 </script>
 
@@ -187,12 +229,24 @@ onBeforeUnmount(() => {
       </template>
       <template #settings>
         <div class="d-flex flex-column ga-4">
-          <div v-if="mode === 'match'">
-            <label class="text-caption text-medium-emphasis d-block mb-1">Pairs</label>
-            <v-btn-toggle :model-value="pairs" mandatory density="compact" variant="outlined" divided @update:model-value="(v: number) => { pairs = v; buildMatch() }">
-              <v-btn v-for="p in [6, 8, 10]" :key="p" :value="p" size="small">{{ p }}</v-btn>
+          <div>
+            <label class="text-caption text-medium-emphasis d-block mb-1">Difficulty</label>
+            <v-btn-toggle :model-value="difficulty" mandatory density="compact" variant="outlined" divided @update:model-value="setDifficulty">
+              <v-btn v-for="d in DIFFICULTY_ORDER" :key="d" :value="d" size="small">{{ difficultyLabels[d] }}</v-btn>
             </v-btn-toggle>
+            <div class="text-caption text-medium-emphasis mt-1">
+              {{ DIFFICULTIES[difficulty].pairs }} pairs · {{ DIFFICULTIES[difficulty].pads }} Simon pads
+            </div>
           </div>
+          <v-btn
+            v-if="audioAvailable"
+            variant="tonal"
+            :color="muted ? undefined : 'primary'"
+            :prepend-icon="muted ? 'mdi-volume-off' : 'mdi-volume-high'"
+            @click="toggleMute"
+          >
+            {{ muted ? 'Sound off' : 'Sound on' }}
+          </v-btn>
           <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New game</v-btn>
         </div>
       </template>
@@ -254,14 +308,14 @@ onBeforeUnmount(() => {
         <div class="text-h6">Level: <span class="font-weight-bold">{{ simonState === 'idle' ? 0 : simonLevel }}</span></div>
         <div class="text-body-2 text-medium-emphasis">Best: {{ simonBest }}</div>
       </div>
-      <div class="simon">
+      <div class="simon" :style="{ gridTemplateColumns: `repeat(${simonCols}, 1fr)` }">
         <button
-          v-for="p in SIMON_PADS"
+          v-for="p in pads"
           :key="p"
           type="button"
           class="pad"
           :class="[`pad--${p - 1}`, { 'pad--active': activePad === p - 1 }]"
-          :aria-label="['green', 'red', 'yellow', 'blue'][p - 1]"
+          :aria-label="PAD_LABELS[p - 1]"
           :disabled="simonState !== 'input'"
           @pointerdown="tapPad(p - 1)"
         />
@@ -329,7 +383,6 @@ onBeforeUnmount(() => {
   grid-template-columns: repeat(2, 1fr);
   gap: 10px;
   max-width: 340px;
-  aspect-ratio: 1;
   margin: 0 auto;
 }
 .pad {
@@ -337,6 +390,7 @@ onBeforeUnmount(() => {
   border-radius: 14px;
   cursor: pointer;
   opacity: 0.55;
+  aspect-ratio: 1;
   transition: opacity 90ms ease, transform 90ms ease, box-shadow 90ms ease;
 }
 .pad:disabled {
@@ -350,10 +404,14 @@ onBeforeUnmount(() => {
 .pad--1 { background: #ef4444; }
 .pad--2 { background: #facc15; }
 .pad--3 { background: #3b82f6; }
+.pad--4 { background: #a855f7; }
+.pad--5 { background: #06b6d4; }
 .pad--active.pad--0 { box-shadow: 0 0 30px #22c55e; }
 .pad--active.pad--1 { box-shadow: 0 0 30px #ef4444; }
 .pad--active.pad--2 { box-shadow: 0 0 30px #facc15; }
 .pad--active.pad--3 { box-shadow: 0 0 30px #3b82f6; }
+.pad--active.pad--4 { box-shadow: 0 0 30px #a855f7; }
+.pad--active.pad--5 { box-shadow: 0 0 30px #06b6d4; }
 
 .simon-center {
   position: absolute;

--- a/src/views/MemoryView.vue
+++ b/src/views/MemoryView.vue
@@ -155,6 +155,7 @@ const setMode = (m: 'match' | 'simon') => {
   mode.value = m
   clearTimers()
   simonState.value = 'idle'
+  activePad.value = -1 // clear any pad left lit by an interrupted playback
   buildMatch()
 }
 
@@ -260,6 +261,7 @@ onBeforeUnmount(() => {
           type="button"
           class="pad"
           :class="[`pad--${p - 1}`, { 'pad--active': activePad === p - 1 }]"
+          :aria-label="['green', 'red', 'yellow', 'blue'][p - 1]"
           :disabled="simonState !== 'input'"
           @pointerdown="tapPad(p - 1)"
         />

--- a/src/views/MemoryView.vue
+++ b/src/views/MemoryView.vue
@@ -1,0 +1,365 @@
+<script setup lang="ts">
+/**
+ * Memory — two quick memory games in one, chosen with a toggle:
+ *  - Match: flip face-down cards two at a time to find all the pairs.
+ *  - Simon: watch a growing color sequence and repeat it back.
+ * Logic (deck build, match rule, stars, sequence check) lives in services/memory.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import GameToolbar from '@/components/GameToolbar.vue'
+import {
+  SIMON_PADS,
+  buildDeck,
+  checkSimon,
+  extendSequence,
+  isMatch,
+  matchStars,
+} from '@/services/memory'
+
+const FACES = ['🍎', '🌟', '🎈', '🐱', '🌸', '⚡', '🍕', '🎸', '🚀', '🎲', '🍩', '👾']
+const SIMON_BEST_KEY = 'simon-best'
+
+const mode = ref<'match' | 'simon'>('match')
+
+// --- Match --------------------------------------------------------------
+const pairs = ref(8)
+const deck = ref<number[]>([])
+const flipped = ref<number[]>([])
+const matched = ref<Set<number>>(new Set())
+const moves = ref(0)
+const lockBoard = ref(false)
+
+const matchCols = computed(() => (pairs.value <= 6 ? 4 : pairs.value <= 8 ? 4 : 5))
+const matchWon = computed(() => deck.value.length > 0 && matched.value.size === deck.value.length)
+
+const buildMatch = () => {
+  deck.value = buildDeck(pairs.value, Math.random)
+  flipped.value = []
+  matched.value = new Set()
+  moves.value = 0
+  lockBoard.value = false
+}
+
+const isFaceUp = (i: number) => flipped.value.includes(i) || matched.value.has(i)
+
+const flipCard = (i: number) => {
+  if (lockBoard.value || isFaceUp(i) || flipped.value.length === 2) return
+  flipped.value = [...flipped.value, i]
+  if (flipped.value.length === 2) {
+    moves.value += 1
+    const [a, b] = flipped.value
+    if (isMatch(deck.value, a, b)) {
+      matched.value = new Set([...matched.value, a, b])
+      flipped.value = []
+    } else {
+      lockBoard.value = true
+      pushTimer(
+        setTimeout(() => {
+          flipped.value = []
+          lockBoard.value = false
+        }, 850),
+      )
+    }
+  }
+}
+
+// --- Simon --------------------------------------------------------------
+const sequence = ref<number[]>([])
+const simonInput = ref<number[]>([])
+const simonState = ref<'idle' | 'show' | 'input' | 'over'>('idle')
+const activePad = ref(-1)
+const simonBest = ref(0)
+
+const simonLevel = computed(() => sequence.value.length)
+
+let timers: ReturnType<typeof setTimeout>[] = []
+const pushTimer = (t: ReturnType<typeof setTimeout>) => timers.push(t)
+const clearTimers = () => {
+  timers.forEach(clearTimeout)
+  timers = []
+}
+
+const playSequence = () => {
+  simonState.value = 'show'
+  activePad.value = -1
+  let i = 0
+  const step = () => {
+    if (i >= sequence.value.length) {
+      simonState.value = 'input'
+      simonInput.value = []
+      return
+    }
+    activePad.value = sequence.value[i]
+    pushTimer(
+      setTimeout(() => {
+        activePad.value = -1
+        i += 1
+        pushTimer(setTimeout(step, 220))
+      }, 460),
+    )
+  }
+  pushTimer(setTimeout(step, 420))
+}
+
+const persistSimonBest = () => {
+  const reached = sequence.value.length - 1 // completed rounds
+  if (reached > simonBest.value) {
+    simonBest.value = reached
+    try {
+      localStorage.setItem(SIMON_BEST_KEY, String(simonBest.value))
+    } catch {
+      // ignore
+    }
+  }
+}
+
+const startSimon = () => {
+  clearTimers()
+  sequence.value = extendSequence([], Math.random)
+  simonInput.value = []
+  simonState.value = 'show'
+  playSequence()
+}
+
+const flashPad = (p: number) => {
+  activePad.value = p
+  pushTimer(
+    setTimeout(() => {
+      if (activePad.value === p) activePad.value = -1
+    }, 180),
+  )
+}
+
+const tapPad = (p: number) => {
+  if (simonState.value !== 'input') return
+  flashPad(p)
+  simonInput.value = [...simonInput.value, p]
+  const result = checkSimon(sequence.value, simonInput.value)
+  if (result === 'wrong') {
+    persistSimonBest()
+    simonState.value = 'over'
+    clearTimers()
+  } else if (result === 'complete') {
+    simonState.value = 'show'
+    pushTimer(
+      setTimeout(() => {
+        sequence.value = extendSequence(sequence.value, Math.random)
+        playSequence()
+      }, 650),
+    )
+  }
+}
+
+// --- Shared -------------------------------------------------------------
+const setMode = (m: 'match' | 'simon') => {
+  mode.value = m
+  clearTimers()
+  simonState.value = 'idle'
+  buildMatch()
+}
+
+const newGame = () => {
+  clearTimers()
+  if (mode.value === 'match') buildMatch()
+  else startSimon()
+}
+
+onMounted(() => {
+  try {
+    simonBest.value = Number(localStorage.getItem(SIMON_BEST_KEY)) || 0
+  } catch {
+    simonBest.value = 0
+  }
+  buildMatch()
+})
+onBeforeUnmount(() => {
+  clearTimers()
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="560">
+    <GameToolbar title="Memory">
+      <template #intro>
+        Two memory games in one. <strong>Match</strong>: flip cards two at a time to find the pairs.
+        <strong>Simon</strong>: watch the color sequence, then repeat it — it grows each round.
+      </template>
+      <template #settings>
+        <div class="d-flex flex-column ga-4">
+          <div v-if="mode === 'match'">
+            <label class="text-caption text-medium-emphasis d-block mb-1">Pairs</label>
+            <v-btn-toggle :model-value="pairs" mandatory density="compact" variant="outlined" divided @update:model-value="(v: number) => { pairs = v; buildMatch() }">
+              <v-btn v-for="p in [6, 8, 10]" :key="p" :value="p" size="small">{{ p }}</v-btn>
+            </v-btn-toggle>
+          </div>
+          <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New game</v-btn>
+        </div>
+      </template>
+      <template #info>
+        <h3>Match</h3>
+        <ul>
+          <li>Tap a card to flip it, then a second. If they match they stay; otherwise they flip back.</li>
+          <li>Clear the board in as few moves as possible — three stars for a near-perfect game.</li>
+        </ul>
+        <h3>Simon</h3>
+        <ul>
+          <li>Watch the pads light up, then tap them back in the same order.</li>
+          <li>Each round adds one more step. One wrong tap ends the run.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <!-- Mode toggle -->
+    <div class="d-flex align-center ga-2 mb-4">
+      <v-btn-toggle :model-value="mode" mandatory density="comfortable" variant="outlined" divided @update:model-value="setMode">
+        <v-btn value="match" size="small" prepend-icon="mdi-cards-outline">Match</v-btn>
+        <v-btn value="simon" size="small" prepend-icon="mdi-view-grid">Simon</v-btn>
+      </v-btn-toggle>
+      <v-spacer />
+      <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New</v-btn>
+    </div>
+
+    <!-- Match mode -->
+    <template v-if="mode === 'match'">
+      <div class="d-flex align-center justify-space-between mb-3">
+        <div class="text-h6">Moves: <span class="font-weight-bold">{{ moves }}</span></div>
+        <div class="text-body-2 text-medium-emphasis">{{ matched.size / 2 }} / {{ pairs }} pairs</div>
+      </div>
+      <div class="match-board" :style="{ gridTemplateColumns: `repeat(${matchCols}, 1fr)` }">
+        <button
+          v-for="(v, i) in deck"
+          :key="i"
+          type="button"
+          class="card"
+          :class="{ 'card--up': isFaceUp(i), 'card--done': matched.has(i) }"
+          @click="flipCard(i)"
+        >
+          <span class="card-face">{{ isFaceUp(i) ? FACES[v] : '' }}</span>
+        </button>
+      </div>
+      <div v-if="matchWon" class="result mt-4">
+        <p class="text-h5 mb-1">Cleared! 🎉</p>
+        <p class="stars mb-2">
+          <v-icon v-for="s in 3" :key="s" :icon="s <= matchStars(pairs, moves) ? 'mdi-star' : 'mdi-star-outline'" color="amber" />
+        </p>
+        <p class="text-body-2 mb-3">{{ moves }} moves</p>
+        <v-btn color="primary" variant="flat" prepend-icon="mdi-refresh" @click="buildMatch">Play again</v-btn>
+      </div>
+    </template>
+
+    <!-- Simon mode -->
+    <template v-else>
+      <div class="d-flex align-center justify-space-between mb-3">
+        <div class="text-h6">Level: <span class="font-weight-bold">{{ simonState === 'idle' ? 0 : simonLevel }}</span></div>
+        <div class="text-body-2 text-medium-emphasis">Best: {{ simonBest }}</div>
+      </div>
+      <div class="simon">
+        <button
+          v-for="p in SIMON_PADS"
+          :key="p"
+          type="button"
+          class="pad"
+          :class="[`pad--${p - 1}`, { 'pad--active': activePad === p - 1 }]"
+          :disabled="simonState !== 'input'"
+          @pointerdown="tapPad(p - 1)"
+        />
+        <div class="simon-center">
+          <span v-if="simonState === 'show'" class="text-caption">Watch…</span>
+          <span v-else-if="simonState === 'input'" class="text-caption">Your turn</span>
+        </div>
+      </div>
+      <div class="result mt-4">
+        <template v-if="simonState === 'idle'">
+          <v-btn color="primary" variant="flat" @click="startSimon">Start</v-btn>
+        </template>
+        <template v-else-if="simonState === 'over'">
+          <p class="text-h6 mb-1">Game over</p>
+          <p class="text-body-2 mb-3">You reached level {{ sequence.length - 1 }}.</p>
+          <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="startSimon">Try again</v-btn>
+        </template>
+      </div>
+    </template>
+  </v-container>
+</template>
+
+<style scoped>
+.match-board {
+  display: grid;
+  gap: 8px;
+  max-width: 460px;
+  margin: 0 auto;
+}
+.card {
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.5), rgba(45, 212, 191, 0.25));
+  cursor: pointer;
+  font-size: clamp(1.4rem, 8vw, 2.2rem);
+  transition: transform 120ms ease, background 120ms ease;
+}
+.card--up {
+  background: rgba(30, 41, 59, 0.9);
+  transform: rotateY(0);
+}
+.card--done {
+  opacity: 0.55;
+  background: rgba(34, 197, 94, 0.2);
+  cursor: default;
+}
+.card-face {
+  line-height: 1;
+}
+
+.result {
+  text-align: center;
+}
+.stars {
+  font-size: 1.6rem;
+}
+
+.simon {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  max-width: 340px;
+  aspect-ratio: 1;
+  margin: 0 auto;
+}
+.pad {
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity 90ms ease, transform 90ms ease, box-shadow 90ms ease;
+}
+.pad:disabled {
+  cursor: default;
+}
+.pad--active {
+  opacity: 1;
+  transform: scale(0.97);
+}
+.pad--0 { background: #22c55e; }
+.pad--1 { background: #ef4444; }
+.pad--2 { background: #facc15; }
+.pad--3 { background: #3b82f6; }
+.pad--active.pad--0 { box-shadow: 0 0 30px #22c55e; }
+.pad--active.pad--1 { box-shadow: 0 0 30px #ef4444; }
+.pad--active.pad--2 { box-shadow: 0 0 30px #facc15; }
+.pad--active.pad--3 { box-shadow: 0 0 30px #3b82f6; }
+
+.simon-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  color: #e2e8f0;
+}
+</style>

--- a/src/views/MiniGolfView.vue
+++ b/src/views/MiniGolfView.vue
@@ -191,30 +191,46 @@ const startRolling = () => {
   raf = requestAnimationFrame(loop)
 }
 
-const pointerPos = (e: PointerEvent, el: HTMLElement) => {
-  const rect = el.getBoundingClientRect()
+// Pointer position relative to the canvas — works even when the pointer is
+// beyond the canvas edges, so the drag can extend off-screen.
+const pointerPos = (e: PointerEvent) => {
+  const canvas = canvasEl.value
+  if (!canvas) return { x: 0, y: 0 }
+  const rect = canvas.getBoundingClientRect()
   return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+}
+
+// While dragging, track the pointer on the window so aim + power keep updating
+// (and the putt still registers) even when the pointer leaves the play area.
+const detachDrag = () => {
+  window.removeEventListener('pointermove', onPointerMove)
+  window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerUp)
 }
 
 const onPointerDown = (e: PointerEvent) => {
   if (phase.value !== 'aim') return
   aiming = true
-  dragStart = pointerPos(e, e.currentTarget as HTMLElement)
+  dragStart = pointerPos(e)
   dragCur = { ...dragStart }
+  window.addEventListener('pointermove', onPointerMove)
+  window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('pointercancel', onPointerUp)
 }
-const onPointerMove = (e: PointerEvent) => {
+function onPointerMove(e: PointerEvent) {
   if (!aiming) return
-  dragCur = pointerPos(e, e.currentTarget as HTMLElement)
+  dragCur = pointerPos(e)
   draw()
 }
-const onPointerUp = () => {
+function onPointerUp() {
   if (!aiming) return
   aiming = false
+  detachDrag()
   const S = boardPx.value
   const dx = dragCur.x - dragStart.x
   const dy = dragCur.y - dragStart.y
   const len = Math.hypot(dx, dy)
-  const power = Math.min(1, len / (MAX_DRAG_FRAC * S))
+  const power = Math.min(1, len / (MAX_DRAG_FRAC * S)) // clamp to full power
   if (power < 0.06) {
     draw()
     return // too small — treat as a cancel
@@ -255,12 +271,10 @@ onMounted(() => {
   seedCode.value = p || randomSeed()
   if (!p) router.replace({ name: 'mini-golf', params: { seed: seedCode.value } })
   loadHole()
-  // Catch a mouse-up that lands outside the canvas so aiming never sticks.
-  window.addEventListener('pointerup', onPointerUp)
 })
 onBeforeUnmount(() => {
   stopLoop()
-  window.removeEventListener('pointerup', onPointerUp)
+  detachDrag()
 })
 </script>
 
@@ -306,9 +320,6 @@ onBeforeUnmount(() => {
         class="canvas"
         :style="{ width: boardPx + 'px', height: boardPx + 'px' }"
         @pointerdown.prevent="onPointerDown"
-        @pointermove="onPointerMove"
-        @pointerup="onPointerUp"
-        @pointercancel="onPointerUp"
       />
 
       <div v-if="phase === 'holed'" class="overlay">

--- a/src/views/MiniGolfView.vue
+++ b/src/views/MiniGolfView.vue
@@ -255,8 +255,13 @@ onMounted(() => {
   seedCode.value = p || randomSeed()
   if (!p) router.replace({ name: 'mini-golf', params: { seed: seedCode.value } })
   loadHole()
+  // Catch a mouse-up that lands outside the canvas so aiming never sticks.
+  window.addEventListener('pointerup', onPointerUp)
 })
-onBeforeUnmount(stopLoop)
+onBeforeUnmount(() => {
+  stopLoop()
+  window.removeEventListener('pointerup', onPointerUp)
+})
 </script>
 
 <template>

--- a/src/views/MiniGolfView.vue
+++ b/src/views/MiniGolfView.vue
@@ -1,0 +1,356 @@
+<script setup lang="ts">
+/**
+ * Mini Golf — a 9-hole seeded course. Drag anywhere and pull back to aim and set
+ * power (like a slingshot), release to putt. Bounce off walls, sink the ball in
+ * the cup in as few strokes as possible; score is total strokes vs par. Physics
+ * and hole layouts come from services/miniGolf; the sim runs in fixed substeps
+ * to avoid tunnelling through thin walls.
+ */
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { copyToClipboard } from '@/services/share'
+import { randomSeed } from '@/services/seed'
+import { useSquareFit } from '@/composables/useSquareFit'
+import {
+  BALL_RADIUS,
+  COURSE_HOLES,
+  aimToVelocity,
+  atRest,
+  inCup,
+  makeHole,
+  step,
+  type BallState,
+  type Hole,
+} from '@/services/miniGolf'
+
+const { el: boardEl, px: boardPx } = useSquareFit(190)
+
+const route = useRoute()
+const router = useRouter()
+
+const STEP_MS = 8
+const MAX_DRAG_FRAC = 0.38 // drag length (fraction of width) for full power
+
+const canvasEl = ref<HTMLCanvasElement | null>(null)
+const seedCode = ref('')
+const holeIndex = ref(0)
+const strokes = ref(0)
+const totalStrokes = ref(0)
+const totalPar = ref(0)
+const phase = ref<'aim' | 'rolling' | 'holed' | 'done'>('aim')
+const snackbar = ref(false)
+
+let hole: Hole = makeHole(0, 'init')
+let ball: BallState = { p: { ...hole.start }, v: { x: 0, y: 0 } }
+let raf = 0
+let lastTs = 0
+let acc = 0
+
+let aiming = false
+let dragStart = { x: 0, y: 0 }
+let dragCur = { x: 0, y: 0 }
+
+const par = computed(() => hole.par)
+const toPar = computed(() => {
+  const diff = totalStrokes.value - totalPar.value
+  if (diff === 0) return 'even'
+  return diff > 0 ? `+${diff}` : `${diff}`
+})
+
+const stopLoop = () => {
+  cancelAnimationFrame(raf)
+  raf = 0
+}
+
+const loadHole = () => {
+  hole = makeHole(holeIndex.value, seedCode.value)
+  ball = { p: { ...hole.start }, v: { x: 0, y: 0 } }
+  strokes.value = 0
+  phase.value = 'aim'
+  aiming = false
+  draw()
+}
+
+const draw = () => {
+  const canvas = canvasEl.value
+  if (!canvas) return
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  const dpr = window.devicePixelRatio || 1
+  const S = boardPx.value
+  if (canvas.width !== S * dpr || canvas.height !== S * dpr) {
+    canvas.width = S * dpr
+    canvas.height = S * dpr
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+  // Green
+  ctx.fillStyle = '#166534'
+  ctx.fillRect(0, 0, S, S)
+  ctx.fillStyle = 'rgba(255,255,255,0.03)'
+  for (let i = 0; i < S; i += 16) ctx.fillRect(0, i, S, 8) // subtle mow stripes
+
+  // Walls
+  ctx.fillStyle = '#5b3a1e'
+  for (const w of hole.walls) ctx.fillRect(w.x * S, w.y * S, w.w * S, w.h * S)
+
+  // Cup + flag
+  const cx = hole.cup.x * S
+  const cy = hole.cup.y * S
+  ctx.beginPath()
+  ctx.arc(cx, cy, hole.cupRadius * S * 0.6, 0, Math.PI * 2)
+  ctx.fillStyle = '#0b1020'
+  ctx.fill()
+  ctx.strokeStyle = '#e2e8f0'
+  ctx.lineWidth = 2
+  ctx.beginPath()
+  ctx.moveTo(cx, cy)
+  ctx.lineTo(cx, cy - S * 0.09)
+  ctx.stroke()
+  ctx.fillStyle = '#ef4444'
+  ctx.beginPath()
+  ctx.moveTo(cx, cy - S * 0.09)
+  ctx.lineTo(cx + S * 0.05, cy - S * 0.075)
+  ctx.lineTo(cx, cy - S * 0.06)
+  ctx.closePath()
+  ctx.fill()
+
+  // Aim line (pull-back-to-shoot)
+  if (aiming) {
+    const dx = dragCur.x - dragStart.x
+    const dy = dragCur.y - dragStart.y
+    const len = Math.hypot(dx, dy)
+    const power = Math.min(1, len / (MAX_DRAG_FRAC * S))
+    const bx = ball.p.x * S
+    const by = ball.p.y * S
+    if (len > 2) {
+      const ux = -dx / len
+      const uy = -dy / len
+      const reach = power * S * 0.4
+      ctx.strokeStyle = `rgba(248, 250, 252, ${0.4 + power * 0.5})`
+      ctx.lineWidth = 3
+      ctx.setLineDash([6, 6])
+      ctx.beginPath()
+      ctx.moveTo(bx, by)
+      ctx.lineTo(bx + ux * reach, by + uy * reach)
+      ctx.stroke()
+      ctx.setLineDash([])
+      // Power pip at the ball
+      ctx.fillStyle = power > 0.85 ? '#ef4444' : '#facc15'
+      ctx.fillRect(bx - 14, by + BALL_RADIUS * S + 6, 28 * power, 4)
+    }
+  }
+
+  // Ball
+  ctx.beginPath()
+  ctx.arc(ball.p.x * S, ball.p.y * S, BALL_RADIUS * S, 0, Math.PI * 2)
+  ctx.fillStyle = '#f8fafc'
+  ctx.shadowColor = 'rgba(0,0,0,0.4)'
+  ctx.shadowBlur = 6
+  ctx.fill()
+  ctx.shadowBlur = 0
+}
+
+const holed = () => {
+  phase.value = 'holed'
+  stopLoop()
+  totalStrokes.value += strokes.value
+  totalPar.value += hole.par
+  draw()
+}
+
+const loop = (ts: number) => {
+  if (phase.value !== 'rolling') return
+  const dt = lastTs ? Math.min(48, ts - lastTs) : STEP_MS
+  lastTs = ts
+  acc += dt
+  while (acc >= STEP_MS) {
+    ball = step(ball, hole.walls, STEP_MS)
+    acc -= STEP_MS
+    if (inCup(ball, hole)) {
+      holed()
+      return
+    }
+  }
+  if (atRest(ball)) {
+    ball.v = { x: 0, y: 0 }
+    phase.value = 'aim'
+    draw()
+    return
+  }
+  draw()
+  raf = requestAnimationFrame(loop)
+}
+
+const startRolling = () => {
+  phase.value = 'rolling'
+  lastTs = 0
+  acc = 0
+  stopLoop()
+  raf = requestAnimationFrame(loop)
+}
+
+const pointerPos = (e: PointerEvent, el: HTMLElement) => {
+  const rect = el.getBoundingClientRect()
+  return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+}
+
+const onPointerDown = (e: PointerEvent) => {
+  if (phase.value !== 'aim') return
+  aiming = true
+  dragStart = pointerPos(e, e.currentTarget as HTMLElement)
+  dragCur = { ...dragStart }
+}
+const onPointerMove = (e: PointerEvent) => {
+  if (!aiming) return
+  dragCur = pointerPos(e, e.currentTarget as HTMLElement)
+  draw()
+}
+const onPointerUp = () => {
+  if (!aiming) return
+  aiming = false
+  const S = boardPx.value
+  const dx = dragCur.x - dragStart.x
+  const dy = dragCur.y - dragStart.y
+  const len = Math.hypot(dx, dy)
+  const power = Math.min(1, len / (MAX_DRAG_FRAC * S))
+  if (power < 0.06) {
+    draw()
+    return // too small — treat as a cancel
+  }
+  ball.v = aimToVelocity({ x: dx / S, y: dy / S }, power)
+  strokes.value += 1
+  startRolling()
+}
+
+const nextHole = () => {
+  if (holeIndex.value + 1 >= COURSE_HOLES) {
+    phase.value = 'done'
+    return
+  }
+  holeIndex.value += 1
+  loadHole()
+}
+
+const newCourse = () => {
+  seedCode.value = randomSeed()
+  router.replace({ name: 'mini-golf', params: { seed: seedCode.value } })
+  holeIndex.value = 0
+  totalStrokes.value = 0
+  totalPar.value = 0
+  loadHole()
+}
+
+const share = async () => {
+  const url = window.location.origin + `/mini-golf/${seedCode.value}`
+  await copyToClipboard(`Play this 9-hole mini golf course:\n${url}`)
+  snackbar.value = true
+}
+
+watch(boardPx, draw)
+
+onMounted(() => {
+  const p = typeof route.params.seed === 'string' ? route.params.seed : ''
+  seedCode.value = p || randomSeed()
+  if (!p) router.replace({ name: 'mini-golf', params: { seed: seedCode.value } })
+  loadHole()
+})
+onBeforeUnmount(stopLoop)
+</script>
+
+<template>
+  <v-container class="py-6" max-width="560">
+    <GameToolbar title="Mini Golf" shareable @share="share">
+      <template #intro>
+        Drag and pull back to aim and set power — like a slingshot — then release to putt. Bounce off
+        the walls and sink the ball in as few strokes as you can, across nine holes.
+      </template>
+      <template #settings>
+        <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newCourse">New course</v-btn>
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Sink the ball in each cup using as few strokes as possible. Your score is total strokes against the course par.</p>
+        <h3>Controls</h3>
+        <ul>
+          <li>Press and drag <em>away</em> from the direction you want to putt — a longer drag means more power.</li>
+          <li>Release to shoot. A tiny drag cancels.</li>
+          <li>The ball must be slow enough over the cup to drop — blast it and it'll lip out.</li>
+        </ul>
+        <h3>Tips</h3>
+        <ul>
+          <li>Use the walls to bank shots around obstacles.</li>
+          <li>Ease off near the hole so the ball stays in.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <!-- HUD -->
+    <div class="d-flex align-center ga-3 mb-3">
+      <div class="text-h6">Hole {{ holeIndex + 1 }}<span class="text-medium-emphasis text-body-2">/{{ COURSE_HOLES }}</span></div>
+      <v-chip size="small" variant="tonal">Par {{ par }}</v-chip>
+      <div class="text-body-2">Strokes: <span class="font-weight-bold">{{ strokes }}</span></div>
+      <v-spacer />
+      <div class="text-body-2 text-medium-emphasis">Total {{ totalStrokes }} ({{ toPar }})</div>
+    </div>
+
+    <div ref="boardEl" class="stage" :style="{ width: boardPx + 'px', height: boardPx + 'px' }">
+      <canvas
+        ref="canvasEl"
+        class="canvas"
+        :style="{ width: boardPx + 'px', height: boardPx + 'px' }"
+        @pointerdown.prevent="onPointerDown"
+        @pointermove="onPointerMove"
+        @pointerup="onPointerUp"
+        @pointercancel="onPointerUp"
+      />
+
+      <div v-if="phase === 'holed'" class="overlay">
+        <p class="text-h4 mb-1">
+          {{ strokes === 1 ? 'Hole in one! 🎉' : `Holed in ${strokes}` }}
+        </p>
+        <p class="text-body-1 mb-4">Par {{ par }} — {{ strokes <= par ? 'nice' : 'keep at it' }}</p>
+        <v-btn color="primary" variant="flat" prepend-icon="mdi-arrow-right" @click="nextHole">
+          {{ holeIndex + 1 >= COURSE_HOLES ? 'Finish' : `Hole ${holeIndex + 2}` }}
+        </v-btn>
+      </div>
+
+      <div v-else-if="phase === 'done'" class="overlay">
+        <p class="text-h4 mb-1">Course complete!</p>
+        <p class="text-body-1 mb-1">{{ totalStrokes }} strokes</p>
+        <p class="text-h6 mb-4">{{ toPar === 'even' ? 'Even par' : `${toPar} to par` }}</p>
+        <v-btn color="primary" variant="flat" prepend-icon="mdi-refresh" @click="newCourse">New course</v-btn>
+      </div>
+    </div>
+
+    <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Course link copied — share it!</v-snackbar>
+  </v-container>
+</template>
+
+<style scoped>
+.stage {
+  position: relative;
+  margin: 0 auto;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 2px solid rgba(120, 80, 40, 0.6);
+  box-shadow: 0 0 40px rgba(22, 101, 52, 0.25);
+}
+.canvas {
+  display: block;
+  touch-action: none;
+}
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0 16px;
+  background: rgba(2, 6, 23, 0.78);
+  backdrop-filter: blur(3px);
+}
+</style>

--- a/src/views/NerdleView.vue
+++ b/src/views/NerdleView.vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+/**
+ * Nerdle — Wordle for arithmetic. Guess the hidden 8-tile equation in six tries;
+ * each tile is scored correct / wrong-place / absent. Guesses must be true,
+ * well-formed equations. Seeded and shareable. Logic lives in services/nerdle.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { copyToClipboard } from '@/services/share'
+import { randomSeed } from '@/services/seed'
+import {
+  MAX_GUESSES,
+  WIDTH,
+  generateEquation,
+  isValidEquation,
+  mergeKeyStatuses,
+  scoreGuess,
+  type TileStatus,
+} from '@/services/nerdle'
+
+const route = useRoute()
+const router = useRouter()
+
+const KEYPAD_TOP = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']
+const KEYPAD_OPS = ['+', '-', '*', '/', '=']
+
+const code = ref('')
+const answer = ref('')
+const guesses = ref<{ text: string; statuses: TileStatus[] }[]>([])
+const current = ref('')
+const gameState = ref<'playing' | 'won' | 'lost'>('playing')
+const keyStatuses = ref<Record<string, TileStatus>>({})
+const shaking = ref(false)
+const message = ref('')
+const snackbar = ref(false)
+
+const displayChar = (ch: string): string => (ch === '*' ? '×' : ch === '/' ? '÷' : ch)
+
+const rows = computed(() => {
+  const out: { char: string; status: TileStatus | 'empty' | 'typing' }[][] = []
+  for (let r = 0; r < MAX_GUESSES; r += 1) {
+    if (r < guesses.value.length) {
+      const g = guesses.value[r]
+      out.push(g.text.split('').map((ch, i) => ({ char: displayChar(ch), status: g.statuses[i] })))
+    } else if (r === guesses.value.length && gameState.value === 'playing') {
+      const cells = []
+      for (let i = 0; i < WIDTH; i += 1) {
+        cells.push({ char: i < current.value.length ? displayChar(current.value[i]) : '', status: 'typing' as const })
+      }
+      out.push(cells)
+    } else {
+      out.push(Array.from({ length: WIDTH }, () => ({ char: '', status: 'empty' as const })))
+    }
+  }
+  return out
+})
+
+const flash = (msg: string) => {
+  message.value = msg
+  snackbar.value = true
+  shaking.value = true
+  setTimeout(() => (shaking.value = false), 420)
+}
+
+const build = () => {
+  answer.value = generateEquation(code.value)
+  guesses.value = []
+  current.value = ''
+  gameState.value = 'playing'
+  keyStatuses.value = {}
+}
+
+const syncUrl = () => router.replace({ name: 'nerdle', params: { seed: code.value } })
+const newGame = () => {
+  code.value = randomSeed()
+  syncUrl()
+  build()
+}
+
+const pressKey = (k: string) => {
+  if (gameState.value !== 'playing') return
+  if (current.value.length < WIDTH) current.value += k
+}
+const del = () => {
+  if (gameState.value !== 'playing') return
+  current.value = current.value.slice(0, -1)
+}
+
+const submit = () => {
+  if (gameState.value !== 'playing') return
+  if (current.value.length !== WIDTH) {
+    flash(`The equation is ${WIDTH} tiles`)
+    return
+  }
+  if (!current.value.includes('=')) {
+    flash('Needs an = sign')
+    return
+  }
+  if (!isValidEquation(current.value)) {
+    flash("That's not a valid equation")
+    return
+  }
+  const statuses = scoreGuess(current.value, answer.value)
+  guesses.value = [...guesses.value, { text: current.value, statuses }]
+  keyStatuses.value = mergeKeyStatuses(keyStatuses.value, current.value, statuses)
+  if (current.value === answer.value) {
+    gameState.value = 'won'
+  } else if (guesses.value.length >= MAX_GUESSES) {
+    gameState.value = 'lost'
+  }
+  current.value = ''
+}
+
+const onKey = (e: KeyboardEvent) => {
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    submit()
+  } else if (e.key === 'Backspace') {
+    e.preventDefault()
+    del()
+  } else if (/^[0-9+\-*/=]$/.test(e.key)) {
+    e.preventDefault()
+    pressKey(e.key)
+  }
+}
+
+const keyClass = (k: string) => {
+  const s = keyStatuses.value[k]
+  return s ? `key--${s}` : ''
+}
+
+const shareText = computed(() => {
+  const emoji: Record<TileStatus, string> = { correct: '🟩', present: '🟪', absent: '⬛' }
+  const grid = guesses.value.map((g) => g.statuses.map((s) => emoji[s]).join('')).join('\n')
+  const score = gameState.value === 'won' ? `${guesses.value.length}/${MAX_GUESSES}` : `X/${MAX_GUESSES}`
+  return `Nerdle ${score}\n${grid}`
+})
+
+const share = async () => {
+  const url = window.location.origin + route.fullPath
+  await copyToClipboard(`${shareText.value}\n${url}`)
+  message.value = 'Result copied — share it!'
+  snackbar.value = true
+}
+
+onMounted(() => {
+  const p = typeof route.params.seed === 'string' ? route.params.seed : ''
+  if (p) {
+    code.value = p
+    build()
+  } else {
+    newGame()
+  }
+  window.addEventListener('keydown', onKey)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKey)
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="520">
+    <GameToolbar title="Nerdle" shareable @share="share">
+      <template #intro>
+        Guess the hidden equation in six tries. Every guess must be a true, well-formed equation.
+        Tiles turn <span class="chip chip--correct">green</span> (right spot),
+        <span class="chip chip--present">purple</span> (wrong spot), or dark (not used).
+      </template>
+      <template #settings>
+        <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New game</v-btn>
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Find the secret equation — digits <span class="k">0–9</span> and <span class="k">+ − × ÷ =</span> across {{ WIDTH }} tiles.</p>
+        <h3>Rules</h3>
+        <ul>
+          <li>Each guess must be arithmetically true (e.g. <span class="k">48-36=12</span>).</li>
+          <li>Standard order of operations applies: × and ÷ before + and −.</li>
+          <li>The value right of <span class="k">=</span> is a plain number, and numbers don't start with 0.</li>
+          <li>Green = correct tile; purple = right symbol, wrong spot; dark = not in the equation.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <div class="d-flex align-center mb-3">
+      <v-spacer />
+      <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New</v-btn>
+    </div>
+
+    <!-- Grid -->
+    <div class="grid" :class="{ shake: shaking }">
+      <div v-for="(row, r) in rows" :key="r" class="grid-row">
+        <div v-for="(tile, c) in row" :key="c" class="tile" :class="`tile--${tile.status}`">
+          {{ tile.char }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Result -->
+    <div v-if="gameState !== 'playing'" class="text-center my-3">
+      <p v-if="gameState === 'won'" class="text-h6 mb-1">Solved in {{ guesses.length }} 🎉</p>
+      <p v-else class="text-h6 mb-1">Out of guesses — it was <strong>{{ answer }}</strong></p>
+      <v-btn color="primary" variant="flat" prepend-icon="mdi-refresh" class="mt-1" @click="newGame">New game</v-btn>
+    </div>
+
+    <!-- Keypad -->
+    <div class="keypad mt-4">
+      <div class="keypad-row">
+        <v-btn v-for="k in KEYPAD_TOP" :key="k" class="key" :class="keyClass(k)" variant="tonal" @click="pressKey(k)">{{ k }}</v-btn>
+      </div>
+      <div class="keypad-row">
+        <v-btn v-for="k in KEYPAD_OPS" :key="k" class="key" :class="keyClass(k)" variant="tonal" @click="pressKey(k)">{{ displayChar(k) }}</v-btn>
+        <v-btn class="key key--wide" variant="tonal" icon="mdi-backspace-outline" @click="del" />
+        <v-btn class="key key--wide" color="primary" variant="flat" @click="submit">Enter</v-btn>
+      </div>
+    </div>
+
+    <v-snackbar v-model="snackbar" :timeout="2200" color="secondary">{{ message }}</v-snackbar>
+  </v-container>
+</template>
+
+<style scoped>
+.grid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+}
+.grid-row {
+  display: flex;
+  gap: 6px;
+}
+.tile {
+  width: clamp(30px, 10vw, 46px);
+  height: clamp(30px, 10vw, 46px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(1rem, 5vw, 1.5rem);
+  font-weight: 700;
+  border-radius: 6px;
+  color: #e2e8f0;
+  border: 2px solid rgba(148, 163, 184, 0.3);
+  background: rgba(30, 41, 59, 0.5);
+}
+.tile--typing {
+  border-color: rgba(148, 163, 184, 0.6);
+}
+.tile--empty {
+  background: rgba(30, 41, 59, 0.25);
+}
+.tile--correct { background: #22c55e; border-color: #22c55e; color: #04210f; }
+.tile--present { background: #a855f7; border-color: #a855f7; color: #1a0533; }
+.tile--absent { background: rgba(30, 41, 59, 0.85); border-color: rgba(71, 85, 105, 0.8); }
+
+.keypad {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+}
+.keypad-row {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.key {
+  min-width: 40px !important;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+.key--wide {
+  min-width: 64px !important;
+}
+.key--correct { background: #22c55e !important; color: #04210f !important; }
+.key--present { background: #a855f7 !important; color: #fff !important; }
+.key--absent { opacity: 0.4; }
+
+.chip {
+  padding: 0 6px;
+  border-radius: 4px;
+  font-weight: 700;
+}
+.chip--correct { background: #22c55e; color: #04210f; }
+.chip--present { background: #a855f7; color: #fff; }
+
+.shake {
+  animation: shake 0.4s ease;
+}
+@keyframes shake {
+  10%, 90% { transform: translateX(-2px); }
+  20%, 80% { transform: translateX(4px); }
+  30%, 50%, 70% { transform: translateX(-6px); }
+  40%, 60% { transform: translateX(6px); }
+}
+</style>

--- a/src/views/NerdleView.vue
+++ b/src/views/NerdleView.vue
@@ -76,6 +76,8 @@ const newGame = () => {
   code.value = randomSeed()
   syncUrl()
   build()
+  // Drop focus from the New button so a subsequent Enter submits, not re-news.
+  if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
 }
 
 const pressKey = (k: string) => {

--- a/src/views/NonogramView.vue
+++ b/src/views/NonogramView.vue
@@ -1,0 +1,305 @@
+<script setup lang="ts">
+/**
+ * Nonogram (Picross) — reveal a hidden picture by filling cells that satisfy the
+ * row/column run-length clues. Drag to paint, right-click / X-mode to mark
+ * "empty". Seeded and shareable; a puzzle is solved when every clue is met.
+ * Clue derivation and checking live in services/nonogram.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { copyToClipboard } from '@/services/share'
+import { randomSeed } from '@/services/seed'
+import { useSquareFit } from '@/composables/useSquareFit'
+import { generateNonogram, isSolved, lineSatisfied, type Nonogram } from '@/services/nonogram'
+
+const { el: boardEl, px: boardPx } = useSquareFit(200)
+
+const route = useRoute()
+const router = useRouter()
+
+const SIZES = [5, 10, 15]
+
+const size = ref(10)
+const code = ref('')
+const puzzle = ref<Nonogram>(generateNonogram(10, 10, 'init'))
+const marks = ref<number[]>([]) // 0 empty · 1 filled · 2 X-marked
+const mode = ref<'fill' | 'mark'>('fill')
+const snackbar = ref(false)
+
+const rows = computed(() => puzzle.value.rows)
+const cols = computed(() => puzzle.value.cols)
+
+const idx = (r: number, c: number) => r * cols.value + c
+
+const maxRowClueLen = computed(() => Math.max(1, ...puzzle.value.rowClues.map((c) => c.length)))
+const maxColClueLen = computed(() => Math.max(1, ...puzzle.value.colClues.map((c) => c.length)))
+
+// Fit clues + board into the measured square.
+const cell = computed(() => {
+  const across = cols.value + maxRowClueLen.value
+  const down = rows.value + maxColClueLen.value
+  return Math.max(16, Math.floor(boardPx.value / Math.max(across, down)))
+})
+const gridStyle = computed(() => ({
+  gridTemplateColumns: `${maxRowClueLen.value * cell.value}px repeat(${cols.value}, ${cell.value}px)`,
+  gridTemplateRows: `${maxColClueLen.value * cell.value}px repeat(${rows.value}, ${cell.value}px)`,
+  fontSize: `${Math.max(9, Math.floor(cell.value * 0.42))}px`,
+}))
+
+const asBool = computed(() => marks.value.map((m) => m === 1))
+const solved = computed(() => marks.value.length > 0 && isSolved(asBool.value, puzzle.value))
+
+// Clue "done" ticks: dim a row/column clue once that line matches.
+const rowDone = (r: number) =>
+  lineSatisfied(asBool.value.slice(r * cols.value, (r + 1) * cols.value), puzzle.value.rowClues[r])
+const colDone = (c: number) => {
+  const line: boolean[] = []
+  for (let r = 0; r < rows.value; r += 1) line.push(asBool.value[idx(r, c)])
+  return lineSatisfied(line, puzzle.value.colClues[c])
+}
+
+const build = () => {
+  puzzle.value = generateNonogram(size.value, size.value, code.value)
+  marks.value = new Array(size.value * size.value).fill(0)
+}
+
+const syncUrl = () => router.replace({ name: 'nonogram', params: { seed: `${size.value}.${code.value}` } })
+const newGame = () => {
+  code.value = randomSeed()
+  syncUrl()
+  build()
+}
+const setSize = (v: number) => {
+  size.value = v
+  newGame()
+}
+
+// --- Painting -----------------------------------------------------------
+let painting = false
+let paintTo = 0
+
+const applyPaint = (i: number) => {
+  if (solved.value) return
+  const cur = marks.value[i]
+  if (mode.value === 'fill') {
+    if (paintTo === 1) marks.value[i] = 1
+    else if (cur === 1) marks.value[i] = 0 // erase only filled cells while dragging
+  } else if (paintTo === 2) {
+    if (cur !== 1) marks.value[i] = 2 // don't X over a filled cell
+  } else if (cur === 2) {
+    marks.value[i] = 0
+  }
+}
+
+const startPaint = (i: number) => {
+  if (solved.value) return
+  const cur = marks.value[i]
+  paintTo = mode.value === 'fill' ? (cur === 1 ? 0 : 1) : cur === 2 ? 0 : 2
+  painting = true
+  applyPaint(i)
+}
+const enterPaint = (i: number) => {
+  if (painting) applyPaint(i)
+}
+const endPaint = () => {
+  painting = false
+}
+
+const toggleX = (i: number) => {
+  if (solved.value) return
+  marks.value[i] = marks.value[i] === 2 ? 0 : 2
+}
+
+const share = async () => {
+  const url = window.location.origin + route.fullPath
+  await copyToClipboard(`Try this ${size.value}×${size.value} Nonogram:\n${url}`)
+  snackbar.value = true
+}
+
+onMounted(() => {
+  const p = typeof route.params.seed === 'string' ? route.params.seed : ''
+  const m = /^(\d+)\.(.+)$/.exec(p)
+  if (m && SIZES.includes(Number(m[1]))) {
+    size.value = Number(m[1])
+    code.value = m[2]
+    build()
+  } else {
+    newGame()
+  }
+  window.addEventListener('pointerup', endPaint)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener('pointerup', endPaint)
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="640">
+    <GameToolbar title="Nonogram" shareable @share="share">
+      <template #intro>
+        Fill the cells so each row and column matches its run-length clues — the numbers count
+        consecutive filled squares. A hidden picture emerges. Drag to paint; right-click to mark X.
+      </template>
+      <template #settings>
+        <div class="d-flex flex-column ga-4">
+          <div>
+            <label class="text-caption text-medium-emphasis d-block mb-1">Size</label>
+            <v-btn-toggle :model-value="size" mandatory density="compact" variant="outlined" divided @update:model-value="setSize">
+              <v-btn v-for="s in SIZES" :key="s" :value="s" size="small">{{ s }}×{{ s }}</v-btn>
+            </v-btn-toggle>
+          </div>
+          <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New puzzle</v-btn>
+        </div>
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Each clue lists the lengths of the filled runs in that row or column, in order, with at least one gap between runs. Deduce which cells are filled.</p>
+        <h3>Controls</h3>
+        <ul>
+          <li>Tap or drag across cells to fill (or erase) them.</li>
+          <li><span class="k">X</span> mode (or right-click) marks a cell you've deduced is empty — just an aid, it doesn't affect solving.</li>
+          <li>A clue dims once its line is satisfied.</li>
+        </ul>
+        <h3>Tips</h3>
+        <ul>
+          <li>Start with clues that nearly fill a line — they leave little freedom.</li>
+          <li>Use X marks to lock in the gaps you're sure about.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <!-- Mode toggle -->
+    <div class="d-flex align-center ga-2 mb-3">
+      <v-btn-toggle v-model="mode" mandatory density="comfortable" variant="outlined" divided>
+        <v-btn value="fill" size="small" prepend-icon="mdi-square"> Fill </v-btn>
+        <v-btn value="mark" size="small" prepend-icon="mdi-close"> Mark </v-btn>
+      </v-btn-toggle>
+      <v-spacer />
+      <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New</v-btn>
+    </div>
+
+    <div ref="boardEl" class="nono-wrap">
+      <div class="nono" :style="gridStyle" @contextmenu.prevent>
+        <!-- Corner -->
+        <div class="corner" />
+        <!-- Column clues -->
+        <div v-for="(clue, c) in puzzle.colClues" :key="'c' + c" class="cclue" :class="{ 'clue--done': colDone(c) }">
+          <span v-for="(n, k) in clue" :key="k">{{ n }}</span>
+        </div>
+        <!-- Rows: row clue + cells -->
+        <template v-for="r in rows" :key="'r' + r">
+          <div class="rclue" :class="{ 'clue--done': rowDone(r - 1) }">
+            <span v-for="(n, k) in puzzle.rowClues[r - 1]" :key="k">{{ n }}</span>
+          </div>
+          <div
+            v-for="c in cols"
+            :key="idx(r - 1, c - 1)"
+            class="ncell"
+            :class="{
+              'ncell--fill': marks[idx(r - 1, c - 1)] === 1,
+              'ncell--x': marks[idx(r - 1, c - 1)] === 2,
+              'ncell--r5': (c - 1) % 5 === 0,
+              'ncell--b5': (r - 1) % 5 === 0,
+            }"
+            @pointerdown.prevent="startPaint(idx(r - 1, c - 1))"
+            @pointerenter="enterPaint(idx(r - 1, c - 1))"
+            @contextmenu.prevent="toggleX(idx(r - 1, c - 1))"
+          >
+            <span v-if="marks[idx(r - 1, c - 1)] === 2" class="x">✕</span>
+          </div>
+        </template>
+      </div>
+
+      <div v-if="solved" class="overlay">
+        <p class="text-h4 mb-1">Solved! 🎉</p>
+        <p class="text-body-1 mb-4">{{ size }}×{{ size }} picture complete.</p>
+        <v-btn color="primary" variant="flat" prepend-icon="mdi-refresh" @click="newGame">New puzzle</v-btn>
+      </div>
+    </div>
+
+    <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Puzzle link copied — share it!</v-snackbar>
+  </v-container>
+</template>
+
+<style scoped>
+.nono-wrap {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+.nono {
+  display: grid;
+  user-select: none;
+  touch-action: none;
+  background: rgba(2, 6, 23, 0.85);
+  border: 2px solid rgba(148, 163, 184, 0.55);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.corner {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.cclue,
+.rclue {
+  display: flex;
+  color: #cbd5e1;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.35);
+}
+.cclue {
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  padding-bottom: 2px;
+  gap: 1px;
+  border-left: 1px solid rgba(148, 163, 184, 0.12);
+}
+.rclue {
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 4px;
+  gap: 4px;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+.clue--done {
+  color: rgba(100, 116, 139, 0.55);
+}
+
+.ncell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-left: 1px solid rgba(148, 163, 184, 0.16);
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(148, 163, 184, 0.04);
+  cursor: pointer;
+}
+.ncell--r5 { border-left-color: rgba(148, 163, 184, 0.5); }
+.ncell--b5 { border-top-color: rgba(148, 163, 184, 0.5); }
+.ncell--fill {
+  background: #7c3aed;
+  box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.9);
+}
+.ncell--x { color: rgba(148, 163, 184, 0.7); }
+.x {
+  font-size: 0.8em;
+  line-height: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: rgba(2, 6, 23, 0.8);
+  backdrop-filter: blur(3px);
+  border-radius: 8px;
+}
+</style>

--- a/src/views/NonogramView.vue
+++ b/src/views/NonogramView.vue
@@ -11,21 +11,45 @@ import GameToolbar from '@/components/GameToolbar.vue'
 import { copyToClipboard } from '@/services/share'
 import { randomSeed } from '@/services/seed'
 import { useSquareFit } from '@/composables/useSquareFit'
-import { generateNonogram, isSolved, lineSatisfied, type Nonogram } from '@/services/nonogram'
+import {
+  generateNonogram,
+  isSolved,
+  lineSatisfied,
+  nonogramFromPattern,
+  type Nonogram,
+} from '@/services/nonogram'
+import { patternById, patternsForSize } from '@/services/nonogramPatterns'
 
-const { el: boardEl, px: boardPx } = useSquareFit(200)
+const { el: boardEl, px: boardPx } = useSquareFit(96)
 
 const route = useRoute()
 const router = useRouter()
 
 const SIZES = [5, 10, 15]
 
+// Fill-color themes for the painted cells (picked in settings).
+const THEMES = [
+  { id: 'violet', label: 'Violet', fill: '#7c3aed' },
+  { id: 'ocean', label: 'Ocean', fill: '#0ea5e9' },
+  { id: 'sunset', label: 'Sunset', fill: '#f97316' },
+  { id: 'forest', label: 'Forest', fill: '#22c55e' },
+] as const
+
 const size = ref(10)
 const code = ref('')
+const pattern = ref('random') // 'random' or a pattern id
+const theme = ref<string>('violet')
 const puzzle = ref<Nonogram>(generateNonogram(10, 10, 'init'))
 const marks = ref<number[]>([]) // 0 empty · 1 filled · 2 X-marked
 const mode = ref<'fill' | 'mark'>('fill')
 const snackbar = ref(false)
+
+// Pictures the player can pick for the current board size.
+const patternOptions = computed(() => [
+  { title: 'Random', value: 'random' },
+  ...patternsForSize(size.value).map((p) => ({ title: p.name, value: p.id })),
+])
+const themeFill = computed(() => THEMES.find((t) => t.id === theme.value)?.fill ?? THEMES[0].fill)
 
 const rows = computed(() => puzzle.value.rows)
 const cols = computed(() => puzzle.value.cols)
@@ -35,16 +59,20 @@ const idx = (r: number, c: number) => r * cols.value + c
 const maxRowClueLen = computed(() => Math.max(1, ...puzzle.value.rowClues.map((c) => c.length)))
 const maxColClueLen = computed(() => Math.max(1, ...puzzle.value.colClues.map((c) => c.length)))
 
-// Fit clues + board into the measured square.
+// Fit clues + board into the measured square. Clamp cells so the board scales
+// UP to fill desktop space (bigger cells) without a single small picture
+// ballooning into absurdly large squares.
 const cell = computed(() => {
   const across = cols.value + maxRowClueLen.value
   const down = rows.value + maxColClueLen.value
-  return Math.max(16, Math.floor(boardPx.value / Math.max(across, down)))
+  const fit = Math.floor(boardPx.value / Math.max(across, down))
+  return Math.min(64, Math.max(16, fit))
 })
 const gridStyle = computed(() => ({
   gridTemplateColumns: `${maxRowClueLen.value * cell.value}px repeat(${cols.value}, ${cell.value}px)`,
   gridTemplateRows: `${maxColClueLen.value * cell.value}px repeat(${rows.value}, ${cell.value}px)`,
   fontSize: `${Math.max(9, Math.floor(cell.value * 0.42))}px`,
+  '--nono-fill': themeFill.value,
 }))
 
 const asBool = computed(() => marks.value.map((m) => m === 1))
@@ -60,19 +88,39 @@ const colDone = (c: number) => {
 }
 
 const build = () => {
+  if (pattern.value !== 'random') {
+    const p = patternById(pattern.value, size.value)
+    if (p) {
+      puzzle.value = nonogramFromPattern(p)
+      marks.value = new Array(size.value * size.value).fill(0)
+      return
+    }
+    pattern.value = 'random' // no such picture at this size — fall back
+  }
   puzzle.value = generateNonogram(size.value, size.value, code.value)
   marks.value = new Array(size.value * size.value).fill(0)
 }
 
-const syncUrl = () => router.replace({ name: 'nonogram', params: { seed: `${size.value}.${code.value}` } })
+// A named picture shares as `@id`; a random puzzle shares its seed code.
+const seedCode = computed(() => (pattern.value === 'random' ? code.value : `@${pattern.value}`))
+const syncUrl = () =>
+  router.replace({ name: 'nonogram', params: { seed: `${size.value}.${seedCode.value}` } })
 const newGame = () => {
-  code.value = randomSeed()
+  if (pattern.value === 'random') code.value = randomSeed()
   syncUrl()
   build()
 }
 const setSize = (v: number) => {
   size.value = v
+  // Drop a picture selection that doesn't exist at the new size.
+  if (pattern.value !== 'random' && !patternById(pattern.value, v)) pattern.value = 'random'
   newGame()
+}
+const setPattern = (v: string | null) => {
+  pattern.value = v ?? 'random'
+  if (pattern.value === 'random' && !code.value) code.value = randomSeed()
+  syncUrl()
+  build()
 }
 
 // --- Painting -----------------------------------------------------------
@@ -131,7 +179,12 @@ onMounted(() => {
   const m = /^(\d+)\.(.+)$/.exec(p)
   if (m && SIZES.includes(Number(m[1]))) {
     size.value = Number(m[1])
-    code.value = m[2]
+    const rest = m[2]
+    if (rest.startsWith('@') && patternById(rest.slice(1), size.value)) {
+      pattern.value = rest.slice(1)
+    } else {
+      code.value = rest
+    }
     build()
   } else {
     newGame()
@@ -144,7 +197,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <v-container class="py-6" max-width="640">
+  <v-container class="py-6" max-width="860">
     <GameToolbar title="Nonogram" shareable @share="share">
       <template #intro>
         Fill the cells so each row and column matches its run-length clues — the numbers count
@@ -156,6 +209,25 @@ onBeforeUnmount(() => {
             <label class="text-caption text-medium-emphasis d-block mb-1">Size</label>
             <v-btn-toggle :model-value="size" mandatory density="compact" variant="outlined" divided @update:model-value="setSize">
               <v-btn v-for="s in SIZES" :key="s" :value="s" size="small">{{ s }}×{{ s }}</v-btn>
+            </v-btn-toggle>
+          </div>
+          <div>
+            <label class="text-caption text-medium-emphasis d-block mb-1">Picture</label>
+            <v-select
+              :model-value="pattern"
+              :items="patternOptions"
+              density="compact"
+              variant="outlined"
+              hide-details
+              @update:model-value="setPattern"
+            />
+          </div>
+          <div>
+            <label class="text-caption text-medium-emphasis d-block mb-1">Fill color</label>
+            <v-btn-toggle v-model="theme" mandatory density="compact" variant="outlined" divided>
+              <v-btn v-for="t in THEMES" :key="t.id" :value="t.id" size="small" :title="t.label">
+                <span class="swatch" :style="{ background: t.fill }" />
+              </v-btn>
             </v-btn-toggle>
           </div>
           <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New puzzle</v-btn>
@@ -290,10 +362,17 @@ onBeforeUnmount(() => {
 .ncell--r5 { border-left-color: rgba(148, 163, 184, 0.5); }
 .ncell--b5 { border-top-color: rgba(148, 163, 184, 0.5); }
 .ncell--fill {
-  background: #7c3aed;
-  box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.9);
+  background: var(--nono-fill, #7c3aed);
+  box-shadow: inset 0 0 0 1px var(--nono-fill, #7c3aed);
 }
 .ncell--x { color: rgba(148, 163, 184, 0.7); }
+.swatch {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
 .x {
   font-size: 0.8em;
   line-height: 1;

--- a/src/views/NonogramView.vue
+++ b/src/views/NonogramView.vue
@@ -92,7 +92,16 @@ const applyPaint = (i: number) => {
   }
 }
 
-const startPaint = (i: number) => {
+const startPaint = (i: number, e: PointerEvent) => {
+  if (e.button !== 0) return // right/middle click is handled by contextmenu (X mark)
+  // Release the implicit pointer capture touch sets on pointerdown, so
+  // pointerenter fires on the cells we drag across (otherwise touch paints
+  // only the first cell).
+  try {
+    ;(e.target as Element).releasePointerCapture?.(e.pointerId)
+  } catch {
+    // no capture to release
+  }
   if (solved.value) return
   const cur = marks.value[i]
   paintTo = mode.value === 'fill' ? (cur === 1 ? 0 : 1) : cur === 2 ? 0 : 2
@@ -202,7 +211,7 @@ onBeforeUnmount(() => {
               'ncell--r5': (c - 1) % 5 === 0,
               'ncell--b5': (r - 1) % 5 === 0,
             }"
-            @pointerdown.prevent="startPaint(idx(r - 1, c - 1))"
+            @pointerdown.prevent="startPaint(idx(r - 1, c - 1), $event)"
             @pointerenter="enterPaint(idx(r - 1, c - 1))"
             @contextmenu.prevent="toggleX(idx(r - 1, c - 1))"
           >

--- a/src/views/SudokuView.vue
+++ b/src/views/SudokuView.vue
@@ -1,0 +1,408 @@
+<script setup lang="ts">
+/**
+ * Sudoku — a seeded, always-unique puzzle with pencil notes, conflict
+ * highlighting, hints, and four difficulties. The puzzle is regenerated from the
+ * URL seed, so a board is shareable. Generation/solving live in services/sudoku.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { copyToClipboard } from '@/services/share'
+import { randomSeed } from '@/services/seed'
+import { useSquareFit } from '@/composables/useSquareFit'
+import {
+  CELLS,
+  N,
+  findConflicts,
+  generatePuzzle,
+  isComplete,
+  type Difficulty,
+  type Grid,
+} from '@/services/sudoku'
+
+const { el: boardEl, px: boardPx } = useSquareFit(220)
+
+const route = useRoute()
+const router = useRouter()
+
+const DIFFICULTIES: Difficulty[] = ['easy', 'medium', 'hard', 'expert']
+
+const difficulty = ref<Difficulty>('easy')
+const code = ref('')
+const cells = ref<Grid>([])
+const given = ref<boolean[]>([])
+const solution = ref<Grid>([])
+const notes = ref<Set<number>[]>([])
+const selected = ref<number | null>(null)
+const notesMode = ref(false)
+const seconds = ref(0)
+const snackbar = ref(false)
+
+let timer: ReturnType<typeof setInterval> | null = null
+
+const conflicts = computed(() => findConflicts(cells.value))
+const solved = computed(() => cells.value.length > 0 && isComplete(cells.value))
+
+// How many of each digit are placed (to dim a digit once all nine are down).
+const digitCounts = computed(() => {
+  const counts = new Array(N + 1).fill(0)
+  for (const v of cells.value) counts[v] += 1
+  return counts
+})
+
+const rowOf = (i: number) => Math.floor(i / N)
+const colOf = (i: number) => i % N
+const boxOf = (i: number) => Math.floor(rowOf(i) / 3) * 3 + Math.floor(colOf(i) / 3)
+
+// Cells sharing a row, column, or box with the selection (for highlighting).
+const peers = computed(() => {
+  const set = new Set<number>()
+  const s = selected.value
+  if (s === null) return set
+  for (let i = 0; i < CELLS; i += 1) {
+    if (rowOf(i) === rowOf(s) || colOf(i) === colOf(s) || boxOf(i) === boxOf(s)) set.add(i)
+  }
+  return set
+})
+
+const selectedValue = computed(() => (selected.value === null ? 0 : cells.value[selected.value]))
+
+const stopTimer = () => {
+  if (timer) clearInterval(timer)
+  timer = null
+}
+const startTimer = () => {
+  stopTimer()
+  timer = setInterval(() => {
+    seconds.value += 1
+  }, 1000)
+}
+const timeLabel = computed(() => {
+  const m = Math.floor(seconds.value / 60)
+  const s = seconds.value % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+})
+
+const build = () => {
+  const puzzle = generatePuzzle(difficulty.value, code.value)
+  cells.value = puzzle.puzzle.slice()
+  given.value = puzzle.given.slice()
+  solution.value = puzzle.solution.slice()
+  notes.value = Array.from({ length: CELLS }, () => new Set<number>())
+  selected.value = null
+  seconds.value = 0
+  startTimer()
+}
+
+const syncUrl = () => router.replace({ name: 'sudoku', params: { seed: `${difficulty.value}.${code.value}` } })
+
+const newGame = () => {
+  code.value = randomSeed()
+  syncUrl()
+  build()
+}
+
+const setDifficulty = (d: Difficulty) => {
+  difficulty.value = d
+  newGame()
+}
+
+const select = (i: number) => {
+  selected.value = i
+}
+
+const clearPeerNotes = (i: number, v: number) => {
+  for (let j = 0; j < CELLS; j += 1) {
+    if (j === i) continue
+    if (rowOf(j) === rowOf(i) || colOf(j) === colOf(i) || boxOf(j) === boxOf(i)) {
+      notes.value[j].delete(v)
+    }
+  }
+}
+
+const inputDigit = (v: number) => {
+  const i = selected.value
+  if (i === null || given.value[i] || solved.value) return
+  if (notesMode.value) {
+    if (cells.value[i]) return // can't note a filled cell
+    const set = notes.value[i]
+    if (set.has(v)) set.delete(v)
+    else set.add(v)
+    notes.value = [...notes.value] // trigger reactivity on the Set mutation
+  } else {
+    const next = cells.value.slice()
+    next[i] = next[i] === v ? 0 : v // tapping the same digit clears it
+    cells.value = next
+    notes.value[i].clear()
+    if (next[i]) clearPeerNotes(i, v)
+    if (solved.value) stopTimer()
+  }
+}
+
+const erase = () => {
+  const i = selected.value
+  if (i === null || given.value[i]) return
+  const next = cells.value.slice()
+  next[i] = 0
+  cells.value = next
+  notes.value[i].clear()
+  notes.value = [...notes.value]
+}
+
+const hint = () => {
+  const i = selected.value
+  if (i === null || given.value[i] || cells.value[i] === solution.value[i]) return
+  const next = cells.value.slice()
+  next[i] = solution.value[i]
+  cells.value = next
+  notes.value[i].clear()
+  clearPeerNotes(i, next[i])
+  if (solved.value) stopTimer()
+}
+
+const move = (dr: number, dc: number) => {
+  const s = selected.value ?? 0
+  const r = Math.min(N - 1, Math.max(0, rowOf(s) + dr))
+  const c = Math.min(N - 1, Math.max(0, colOf(s) + dc))
+  selected.value = r * N + c
+}
+
+const onKey = (e: KeyboardEvent) => {
+  if (e.key >= '1' && e.key <= '9') {
+    e.preventDefault()
+    inputDigit(Number(e.key))
+  } else if (e.key === 'Backspace' || e.key === 'Delete' || e.key === '0') {
+    e.preventDefault()
+    erase()
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    move(-1, 0)
+  } else if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    move(1, 0)
+  } else if (e.key === 'ArrowLeft') {
+    e.preventDefault()
+    move(0, -1)
+  } else if (e.key === 'ArrowRight') {
+    e.preventDefault()
+    move(0, 1)
+  } else if (e.key === 'n' || e.key === 'N') {
+    notesMode.value = !notesMode.value
+  }
+}
+
+const cellClass = (i: number) => ({
+  'cell--given': given.value[i],
+  'cell--selected': selected.value === i,
+  'cell--peer': selected.value !== null && selected.value !== i && peers.value.has(i),
+  'cell--same': selectedValue.value > 0 && cells.value[i] === selectedValue.value,
+  'cell--conflict': conflicts.value.has(i),
+  'cell--r3': colOf(i) % 3 === 0,
+  'cell--b3': rowOf(i) % 3 === 0,
+})
+
+const share = async () => {
+  const url = window.location.origin + route.fullPath
+  await copyToClipboard(`Try this ${difficulty.value} Sudoku:\n${url}`)
+  snackbar.value = true
+}
+
+onMounted(() => {
+  const p = typeof route.params.seed === 'string' ? route.params.seed : ''
+  const m = /^(easy|medium|hard|expert)\.(.+)$/.exec(p)
+  if (m) {
+    difficulty.value = m[1] as Difficulty
+    code.value = m[2]
+    build()
+  } else {
+    newGame()
+  }
+  window.addEventListener('keydown', onKey)
+})
+onBeforeUnmount(() => {
+  stopTimer()
+  window.removeEventListener('keydown', onKey)
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="620">
+    <GameToolbar title="Sudoku" shareable @share="share">
+      <template #intro>
+        Fill the grid so every row, column, and 3×3 box holds 1–9. Tap a cell, then a number — or
+        use the keyboard. It's a fresh, always-solvable puzzle every time.
+      </template>
+      <template #settings>
+        <div class="d-flex flex-column ga-4">
+          <div>
+            <label class="text-caption text-medium-emphasis d-block mb-1">Difficulty</label>
+            <v-btn-toggle
+              :model-value="difficulty"
+              mandatory
+              density="compact"
+              variant="outlined"
+              divided
+              @update:model-value="setDifficulty"
+            >
+              <v-btn v-for="d in DIFFICULTIES" :key="d" :value="d" size="small" class="text-capitalize">{{ d }}</v-btn>
+            </v-btn-toggle>
+          </div>
+          <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New puzzle</v-btn>
+        </div>
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Place the digits 1–9 so that each row, each column, and each 3×3 box contains every digit exactly once.</p>
+        <h3>Controls</h3>
+        <ul>
+          <li>Click/tap a cell, then a number (or press <span class="k">1</span>–<span class="k">9</span>).</li>
+          <li><span class="k">Notes</span> mode (or <span class="k">N</span>) pencils in small candidates.</li>
+          <li><span class="k">Backspace</span> / the erase button clears a cell; arrow keys move.</li>
+          <li><span class="k">Hint</span> fills the selected cell with its correct value.</li>
+        </ul>
+        <h3>Difficulty</h3>
+        <p>Higher difficulties start with fewer given numbers. Every puzzle is guaranteed to have exactly one solution.</p>
+      </template>
+    </GameToolbar>
+
+    <!-- Status bar -->
+    <div class="d-flex align-center ga-3 mb-3">
+      <v-chip variant="tonal" class="text-capitalize">{{ difficulty }}</v-chip>
+      <div class="text-body-1"><v-icon icon="mdi-clock-outline" size="small" /> {{ timeLabel }}</div>
+      <v-spacer />
+      <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New</v-btn>
+    </div>
+
+    <!-- Board -->
+    <div ref="boardEl" class="board-wrap" :style="{ width: boardPx + 'px', height: boardPx + 'px' }">
+      <div class="board">
+        <button
+          v-for="(v, i) in cells"
+          :key="i"
+          type="button"
+          class="cell"
+          :class="cellClass(i)"
+          @click="select(i)"
+        >
+          <span v-if="v" class="cell-value">{{ v }}</span>
+          <span v-else-if="notes[i] && notes[i].size" class="notes">
+            <span v-for="n in 9" :key="n" class="note">{{ notes[i].has(n) ? n : '' }}</span>
+          </span>
+        </button>
+      </div>
+      <div v-if="solved" class="overlay">
+        <p class="text-h4 mb-1">Solved! 🎉</p>
+        <p class="text-body-1 mb-4">{{ difficulty }} · {{ timeLabel }}</p>
+        <v-btn color="primary" variant="flat" prepend-icon="mdi-refresh" @click="newGame">New puzzle</v-btn>
+      </div>
+    </div>
+
+    <!-- Number pad -->
+    <div class="pad mt-4">
+      <v-btn
+        v-for="n in 9"
+        :key="n"
+        class="pad-btn"
+        variant="tonal"
+        :disabled="digitCounts[n] >= 9"
+        @click="inputDigit(n)"
+      >{{ n }}</v-btn>
+    </div>
+
+    <!-- Tools -->
+    <div class="d-flex justify-center ga-2 mt-3 flex-wrap">
+      <v-btn :variant="notesMode ? 'flat' : 'tonal'" :color="notesMode ? 'primary' : undefined" prepend-icon="mdi-pencil-outline" @click="notesMode = !notesMode">
+        Notes {{ notesMode ? 'on' : 'off' }}
+      </v-btn>
+      <v-btn variant="tonal" prepend-icon="mdi-eraser" @click="erase">Erase</v-btn>
+      <v-btn variant="tonal" prepend-icon="mdi-lightbulb-on-outline" @click="hint">Hint</v-btn>
+    </div>
+
+    <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Puzzle link copied — share it!</v-snackbar>
+  </v-container>
+</template>
+
+<style scoped>
+.board-wrap {
+  position: relative;
+}
+.board {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  grid-template-rows: repeat(9, 1fr);
+  width: 100%;
+  height: 100%;
+  border: 2px solid rgba(148, 163, 184, 0.7);
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(2, 6, 23, 0.85);
+  user-select: none;
+}
+
+.cell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  font-size: clamp(1rem, 5vw, 1.6rem);
+  color: #93c5fd; /* player entries: light blue */
+  background: transparent;
+  cursor: pointer;
+  transition: background 90ms ease;
+}
+/* Thicker lines between 3×3 boxes */
+.cell--r3 { border-left: 2px solid rgba(148, 163, 184, 0.6); }
+.cell--b3 { border-top: 2px solid rgba(148, 163, 184, 0.6); }
+
+.cell--given {
+  color: #e2e8f0;
+  font-weight: 700;
+  cursor: default;
+}
+.cell--peer { background: rgba(148, 163, 184, 0.08); }
+.cell--same { background: rgba(59, 130, 246, 0.22); }
+.cell--selected { background: rgba(59, 130, 246, 0.38); }
+.cell--conflict { color: #f87171; background: rgba(248, 113, 113, 0.18); }
+
+.notes {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  width: 100%;
+  height: 100%;
+  padding: 2px;
+}
+.note {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.55rem;
+  line-height: 1;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  text-transform: capitalize;
+  background: rgba(2, 6, 23, 0.8);
+  backdrop-filter: blur(3px);
+  border-radius: 8px;
+}
+
+.pad {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: 6px;
+}
+.pad-btn {
+  min-width: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+</style>

--- a/src/views/SudokuView.vue
+++ b/src/views/SudokuView.vue
@@ -19,6 +19,7 @@ import {
   type Difficulty,
   type Grid,
 } from '@/services/sudoku'
+import { findHint, type Hint } from '@/services/sudokuHints'
 
 const { el: boardEl, px: boardPx } = useSquareFit(220)
 
@@ -37,6 +38,16 @@ const selected = ref<number | null>(null)
 const notesMode = ref(false)
 const seconds = ref(0)
 const snackbar = ref(false)
+
+// Number lock: long-press a pad digit to keep it active so every cell tap
+// places it. `lockedDigit` is the pinned value (null = off).
+const lockedDigit = ref<number | null>(null)
+
+// Progressive hints: `activeHint` is the current technique found by the
+// strategy solver; `hintLevel` indexes into its `levels` nudges.
+const activeHint = ref<Hint | null>(null)
+const hintLevel = ref(0)
+const hintMessage = ref('')
 
 let timer: ReturnType<typeof setInterval> | null = null
 
@@ -67,6 +78,28 @@ const peers = computed(() => {
 
 const selectedValue = computed(() => (selected.value === null ? 0 : cells.value[selected.value]))
 
+// From the "exact cell" step on, highlight the cells the hint is about.
+const hintCells = computed(() => {
+  const set = new Set<number>()
+  if (activeHint.value && hintLevel.value >= 2) {
+    for (const c of activeHint.value.cells) set.add(c)
+  }
+  return set
+})
+const hintElimCells = computed(() => {
+  const set = new Set<number>()
+  if (activeHint.value && hintLevel.value >= 2) {
+    for (const e of activeHint.value.eliminations) set.add(e.cell)
+  }
+  return set
+})
+
+const clearHint = () => {
+  activeHint.value = null
+  hintLevel.value = 0
+  hintMessage.value = ''
+}
+
 const stopTimer = () => {
   if (timer) clearInterval(timer)
   timer = null
@@ -90,6 +123,8 @@ const build = () => {
   solution.value = puzzle.solution.slice()
   notes.value = Array.from({ length: CELLS }, () => new Set<number>())
   selected.value = null
+  lockedDigit.value = null
+  clearHint()
   seconds.value = 0
   startTimer()
 }
@@ -109,6 +144,8 @@ const setDifficulty = (d: Difficulty) => {
 
 const select = (i: number) => {
   selected.value = i
+  // With a locked digit, tapping a cell places that digit straight away.
+  if (lockedDigit.value !== null) placeLocked(i)
 }
 
 const clearPeerNotes = (i: number, v: number) => {
@@ -123,6 +160,7 @@ const clearPeerNotes = (i: number, v: number) => {
 const inputDigit = (v: number) => {
   const i = selected.value
   if (i === null || given.value[i] || solved.value) return
+  clearHint()
   if (notesMode.value) {
     if (cells.value[i]) return // can't note a filled cell
     const set = notes.value[i]
@@ -140,9 +178,73 @@ const inputDigit = (v: number) => {
   }
 }
 
+// Place the currently locked digit into cell `i` (used by cell taps in lock
+// mode). Unlike inputDigit it never toggles off, and auto-advances the lock.
+const placeLocked = (i: number) => {
+  const v = lockedDigit.value
+  if (v === null || given.value[i] || solved.value) return
+  clearHint()
+  const next = cells.value.slice()
+  next[i] = v
+  cells.value = next
+  notes.value[i].clear()
+  clearPeerNotes(i, v)
+  notes.value = [...notes.value]
+  advanceLock()
+  if (solved.value) stopTimer()
+}
+
+// Once every copy of the locked digit is placed, jump the lock to the next
+// digit that still has cells to fill; turn it off when the board is full.
+const advanceLock = () => {
+  const v = lockedDigit.value
+  if (v === null || digitCounts.value[v] < 9) return
+  for (let step = 1; step <= N; step += 1) {
+    const d = ((v - 1 + step) % N) + 1
+    if (digitCounts.value[d] < 9) {
+      lockedDigit.value = d
+      return
+    }
+  }
+  lockedDigit.value = null
+}
+
+// Number-pad tap (not a long-press): manage the lock, else place normally.
+const tapPad = (n: number) => {
+  if (lockedDigit.value !== null) {
+    // Tapping the locked digit turns the lock off; a different one switches it.
+    lockedDigit.value = lockedDigit.value === n ? null : n
+    return
+  }
+  inputDigit(n)
+}
+
+// Long-press wiring for locking a pad digit.
+let pressTimer: ReturnType<typeof setTimeout> | null = null
+let longPressed = false
+const startPress = (n: number) => {
+  longPressed = false
+  pressTimer = setTimeout(() => {
+    longPressed = true
+    lockedDigit.value = n
+  }, 450)
+}
+const endPress = () => {
+  if (pressTimer) clearTimeout(pressTimer)
+  pressTimer = null
+}
+const clickPad = (n: number) => {
+  if (longPressed) {
+    longPressed = false // long-press already handled the lock; swallow the click
+    return
+  }
+  tapPad(n)
+}
+
 const erase = () => {
   const i = selected.value
   if (i === null || given.value[i] || solved.value) return
+  clearHint()
   const next = cells.value.slice()
   next[i] = 0
   cells.value = next
@@ -150,22 +252,67 @@ const erase = () => {
   notes.value = [...notes.value]
 }
 
-const hint = () => {
-  if (solved.value) return
-  let i = selected.value
-  // With no usable selection, hint the first cell that's still empty or wrong.
-  if (i === null || given.value[i] || cells.value[i] === solution.value[i]) {
-    i = cells.value.findIndex((v, idx) => !given.value[idx] && v !== solution.value[idx])
-    if (i === -1) return
-    selected.value = i
-  }
+// Fallback when no supported human technique applies: reveal a single cell
+// from the stored solution (the old hint behaviour).
+const revealCell = () => {
+  const i = cells.value.findIndex((v, idx) => !given.value[idx] && v !== solution.value[idx])
+  if (i === -1) return
+  selected.value = i
   const next = cells.value.slice()
   next[i] = solution.value[i]
   cells.value = next
   notes.value[i].clear()
   clearPeerNotes(i, next[i])
   notes.value = [...notes.value]
+  hintMessage.value = `No forced move found — revealed row ${rowOf(i) + 1}, column ${colOf(i) + 1} for you.`
   if (solved.value) stopTimer()
+}
+
+const applyHint = (h: Hint) => {
+  if (h.placement) {
+    const { cell, value } = h.placement
+    if (given.value[cell] || solved.value) return
+    const next = cells.value.slice()
+    next[cell] = value
+    cells.value = next
+    notes.value[cell].clear()
+    clearPeerNotes(cell, value)
+    notes.value = [...notes.value]
+    if (solved.value) stopTimer()
+  } else {
+    // Elimination techniques: strike the ruled-out candidates from any notes.
+    for (const e of h.eliminations) notes.value[e.cell].delete(e.value)
+    notes.value = [...notes.value]
+  }
+}
+
+// Progressive hint: first press finds the easiest technique and states it;
+// each subsequent press narrows in, then highlights the cell, then reveals /
+// applies the move on the final step.
+const hint = () => {
+  if (solved.value) return
+  const current = activeHint.value
+  if (!current) {
+    const h = findHint(cells.value)
+    if (!h) {
+      revealCell()
+      return
+    }
+    activeHint.value = h
+    hintLevel.value = 0
+    hintMessage.value = h.levels[0]
+    return
+  }
+  if (hintLevel.value < current.levels.length - 1) {
+    hintLevel.value += 1
+    hintMessage.value = current.levels[hintLevel.value]
+    if (hintLevel.value >= 2 && current.cells.length) selected.value = current.cells[0]
+    if (hintLevel.value === current.levels.length - 1) applyHint(current)
+    return
+  }
+  // Final step already applied — clear and look for the next move.
+  clearHint()
+  hint()
 }
 
 const move = (dr: number, dc: number) => {
@@ -205,6 +352,8 @@ const cellClass = (i: number) => ({
   'cell--peer': selected.value !== null && selected.value !== i && peers.value.has(i),
   'cell--same': selectedValue.value > 0 && cells.value[i] === selectedValue.value,
   'cell--conflict': conflicts.value.has(i),
+  'cell--hint': hintCells.value.has(i),
+  'cell--hint-elim': hintElimCells.value.has(i),
   'cell--r3': colOf(i) % 3 === 0,
   'cell--b3': rowOf(i) % 3 === 0,
 })
@@ -266,7 +415,8 @@ onBeforeUnmount(() => {
           <li>Click/tap a cell, then a number (or press <span class="k">1</span>–<span class="k">9</span>).</li>
           <li><span class="k">Notes</span> mode (or <span class="k">N</span>) pencils in small candidates.</li>
           <li><span class="k">Backspace</span> / the erase button clears a cell; arrow keys move.</li>
-          <li><span class="k">Hint</span> fills the selected cell with its correct value.</li>
+          <li><strong>Long-press a number</strong> to lock it: every cell you tap then gets that digit, and the lock jumps to the next digit once all nine are placed. Tap it again to unlock.</li>
+          <li><span class="k">Hint</span> finds the next logical move by name (naked/hidden single, locked candidate, pairs) and nudges you step by step — press again to narrow in, and only the last step reveals the value.</li>
         </ul>
         <h3>Difficulty</h3>
         <p>Higher difficulties start with fewer given numbers. Every puzzle is guaranteed to have exactly one solution.</p>
@@ -305,17 +455,48 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
-    <!-- Number pad -->
+    <!-- Number pad (long-press a digit to lock it) -->
     <div class="pad mt-4">
       <v-btn
         v-for="n in 9"
         :key="n"
         class="pad-btn"
-        variant="tonal"
+        :class="{ 'pad-btn--locked': lockedDigit === n }"
+        :variant="lockedDigit === n ? 'flat' : 'tonal'"
+        :color="lockedDigit === n ? 'primary' : undefined"
         :disabled="digitCounts[n] >= 9"
-        @click="inputDigit(n)"
+        @pointerdown="startPress(n)"
+        @pointerup="endPress"
+        @pointerleave="endPress"
+        @pointercancel="endPress"
+        @contextmenu.prevent
+        @click="clickPad(n)"
       >{{ n }}</v-btn>
     </div>
+
+    <!-- Lock status -->
+    <div class="text-center text-caption text-medium-emphasis mt-2" style="min-height: 1.2em">
+      <template v-if="lockedDigit !== null">
+        <v-icon icon="mdi-lock" size="x-small" /> {{ lockedDigit }} locked — tap cells to place it. Tap {{ lockedDigit }} again to unlock.
+      </template>
+      <template v-else>Long-press a number to lock it for repeated placement.</template>
+    </div>
+
+    <!-- Progressive hint banner -->
+    <v-alert
+      v-if="hintMessage"
+      class="mt-3"
+      type="info"
+      variant="tonal"
+      density="comfortable"
+      closable
+      @click:close="clearHint"
+    >
+      {{ hintMessage }}
+      <template v-if="activeHint" #append>
+        <span class="text-caption">{{ hintLevel + 1 }}/{{ activeHint.levels.length }}</span>
+      </template>
+    </v-alert>
 
     <!-- Tools -->
     <div class="d-flex justify-center ga-2 mt-3 flex-wrap">
@@ -323,7 +504,9 @@ onBeforeUnmount(() => {
         Notes {{ notesMode ? 'on' : 'off' }}
       </v-btn>
       <v-btn variant="tonal" prepend-icon="mdi-eraser" @click="erase">Erase</v-btn>
-      <v-btn variant="tonal" prepend-icon="mdi-lightbulb-on-outline" @click="hint">Hint</v-btn>
+      <v-btn variant="tonal" prepend-icon="mdi-lightbulb-on-outline" @click="hint">
+        {{ activeHint ? 'Next hint' : 'Hint' }}
+      </v-btn>
     </div>
 
     <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Puzzle link copied — share it!</v-snackbar>
@@ -372,6 +555,12 @@ onBeforeUnmount(() => {
 .cell--same { background: rgba(59, 130, 246, 0.22); }
 .cell--selected { background: rgba(59, 130, 246, 0.38); }
 .cell--conflict { color: #f87171; background: rgba(248, 113, 113, 0.18); }
+/* Hint highlighting: target cell(s) glow, elimination cells get a softer tint */
+.cell--hint-elim { background: rgba(250, 204, 21, 0.14); }
+.cell--hint {
+  background: rgba(250, 204, 21, 0.3);
+  box-shadow: inset 0 0 0 2px rgba(250, 204, 21, 0.85);
+}
 
 .notes {
   display: grid;
@@ -412,5 +601,9 @@ onBeforeUnmount(() => {
   min-width: 0;
   font-size: 1.15rem;
   font-weight: 700;
+  touch-action: manipulation; /* avoid text-selection / callout on long-press */
+}
+.pad-btn--locked {
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.6);
 }
 </style>

--- a/src/views/SudokuView.vue
+++ b/src/views/SudokuView.vue
@@ -135,13 +135,14 @@ const inputDigit = (v: number) => {
     cells.value = next
     notes.value[i].clear()
     if (next[i]) clearPeerNotes(i, v)
+    notes.value = [...notes.value]
     if (solved.value) stopTimer()
   }
 }
 
 const erase = () => {
   const i = selected.value
-  if (i === null || given.value[i]) return
+  if (i === null || given.value[i] || solved.value) return
   const next = cells.value.slice()
   next[i] = 0
   cells.value = next
@@ -150,13 +151,20 @@ const erase = () => {
 }
 
 const hint = () => {
-  const i = selected.value
-  if (i === null || given.value[i] || cells.value[i] === solution.value[i]) return
+  if (solved.value) return
+  let i = selected.value
+  // With no usable selection, hint the first cell that's still empty or wrong.
+  if (i === null || given.value[i] || cells.value[i] === solution.value[i]) {
+    i = cells.value.findIndex((v, idx) => !given.value[idx] && v !== solution.value[idx])
+    if (i === -1) return
+    selected.value = i
+  }
   const next = cells.value.slice()
   next[i] = solution.value[i]
   cells.value = next
   notes.value[i].clear()
   clearPeerNotes(i, next[i])
+  notes.value = [...notes.value]
   if (solved.value) stopTimer()
 }
 

--- a/src/views/TangoView.vue
+++ b/src/views/TangoView.vue
@@ -1,0 +1,235 @@
+<script setup lang="ts">
+/**
+ * Tango — a 6×6 fill-the-grid logic puzzle. Each cell is a Sun or Moon. Balance
+ * every row and column (three each), never place three of a kind in a row, and
+ * honor the "=" (equal) and "×" (opposite) badges between neighbors. Seeded and
+ * shareable. Generation/checking live in services/tango.
+ */
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { copyToClipboard } from '@/services/share'
+import { randomSeed } from '@/services/seed'
+import { useSquareFit } from '@/composables/useSquareFit'
+import {
+  CELLS,
+  EMPTY,
+  MOON,
+  SIZE,
+  SUN,
+  findConflicts,
+  generateTango,
+  isSolved,
+  type Constraint,
+  type Grid,
+} from '@/services/tango'
+
+const { el: boardEl, px: boardPx } = useSquareFit(170)
+const cell = computed(() => boardPx.value / SIZE)
+
+const route = useRoute()
+const router = useRouter()
+
+const code = ref('')
+const cells = ref<Grid>(new Array(CELLS).fill(EMPTY))
+const given = ref<boolean[]>([])
+const solution = ref<Grid>([])
+const constraints = ref<Constraint[]>([])
+const snackbar = ref(false)
+
+const conflicts = computed(() => findConflicts(cells.value, constraints.value))
+const solved = computed(() => cells.value.length > 0 && isSolved(cells.value, constraints.value))
+
+// Badge positions between constrained neighbors, in board pixels.
+const badges = computed(() =>
+  constraints.value.map((con) => {
+    const [ra, ca] = [Math.floor(con.a / SIZE), con.a % SIZE]
+    const horizontal = con.b === con.a + 1
+    const x = horizontal ? (ca + 1) * cell.value : (ca + 0.5) * cell.value
+    const y = horizontal ? (ra + 0.5) * cell.value : (ra + 1) * cell.value
+    return { x, y, symbol: con.kind === 'eq' ? '=' : '×' }
+  }),
+)
+
+const build = () => {
+  const puzzle = generateTango(code.value)
+  cells.value = puzzle.given.slice()
+  given.value = puzzle.given.map((v) => v !== EMPTY)
+  solution.value = puzzle.solution.slice()
+  constraints.value = puzzle.constraints
+}
+
+const syncUrl = () => router.replace({ name: 'tango', params: { seed: code.value } })
+const newGame = () => {
+  code.value = randomSeed()
+  syncUrl()
+  build()
+}
+
+const cycle = (i: number) => {
+  if (given.value[i] || solved.value) return
+  const next = cells.value.slice()
+  next[i] = next[i] === EMPTY ? SUN : next[i] === SUN ? MOON : EMPTY
+  cells.value = next
+}
+
+const share = async () => {
+  const url = window.location.origin + route.fullPath
+  await copyToClipboard(`Try this Tango puzzle:\n${url}`)
+  snackbar.value = true
+}
+
+onMounted(() => {
+  const p = typeof route.params.seed === 'string' ? route.params.seed : ''
+  if (p) {
+    code.value = p
+    build()
+  } else {
+    newGame()
+  }
+})
+
+const cellClass = (i: number) => ({
+  'tcell--given': given.value[i],
+  'tcell--conflict': conflicts.value.has(i),
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="560">
+    <GameToolbar title="Tango" shareable @share="share">
+      <template #intro>
+        Fill every cell with a Sun or a Moon. Each row and column needs three of each, no three of a
+        kind may sit in a row, and the <strong>=</strong> / <strong>×</strong> badges link neighbors.
+        Tap a cell to cycle Sun → Moon → empty.
+      </template>
+      <template #settings>
+        <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New puzzle</v-btn>
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Complete the grid so it obeys every rule at once.</p>
+        <h3>Rules</h3>
+        <ul>
+          <li>Each row and each column has exactly three Suns and three Moons.</li>
+          <li>No three of the same symbol are next to each other, across or down.</li>
+          <li><strong>=</strong> between two cells: they must match. <strong>×</strong>: they must differ.</li>
+        </ul>
+        <h3>Tips</h3>
+        <ul>
+          <li>Every puzzle is solvable by logic alone — no guessing needed.</li>
+          <li>A pair of same symbols forces the cells on either side to be the opposite.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <div class="d-flex align-center ga-3 mb-3">
+      <v-spacer />
+      <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New</v-btn>
+    </div>
+
+    <div ref="boardEl" class="board-wrap" :style="{ width: boardPx + 'px', height: boardPx + 'px' }">
+      <div class="board" :style="{ gridTemplateColumns: `repeat(${SIZE}, 1fr)` }">
+        <button
+          v-for="(v, i) in cells"
+          :key="i"
+          type="button"
+          class="tcell"
+          :class="cellClass(i)"
+          @click="cycle(i)"
+        >
+          <v-icon v-if="v === SUN" icon="mdi-white-balance-sunny" class="sun" :size="cell * 0.6" />
+          <v-icon v-else-if="v === MOON" icon="mdi-moon-waning-crescent" class="moon" :size="cell * 0.6" />
+        </button>
+      </div>
+
+      <!-- Constraint badges between neighbors -->
+      <div
+        v-for="(b, k) in badges"
+        :key="k"
+        class="badge"
+        :style="{ left: b.x + 'px', top: b.y + 'px' }"
+      >{{ b.symbol }}</div>
+
+      <div v-if="solved" class="overlay">
+        <p class="text-h4 mb-1">Solved! 🎉</p>
+        <p class="text-body-1 mb-4">Every rule satisfied.</p>
+        <v-btn color="primary" variant="flat" prepend-icon="mdi-refresh" @click="newGame">New puzzle</v-btn>
+      </div>
+    </div>
+
+    <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Puzzle link copied — share it!</v-snackbar>
+  </v-container>
+</template>
+
+<style scoped>
+.board-wrap {
+  position: relative;
+  margin: 0 auto;
+}
+.board {
+  display: grid;
+  gap: 0;
+  width: 100%;
+  height: 100%;
+  border: 2px solid rgba(148, 163, 184, 0.55);
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(2, 6, 23, 0.85);
+  user-select: none;
+}
+.tcell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(148, 163, 184, 0.03);
+  cursor: pointer;
+  transition: background 90ms ease;
+}
+.tcell--given {
+  background: rgba(148, 163, 184, 0.14);
+  cursor: default;
+}
+.tcell--conflict {
+  background: rgba(248, 113, 113, 0.22);
+}
+.sun {
+  color: #facc15;
+}
+.moon {
+  color: #818cf8;
+}
+
+.badge {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-size: 0.95rem;
+  color: #0f172a;
+  background: #e2e8f0;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px rgba(2, 6, 23, 0.85);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: rgba(2, 6, 23, 0.8);
+  backdrop-filter: blur(3px);
+  border-radius: 8px;
+}
+</style>
+

--- a/src/views/TangoView.vue
+++ b/src/views/TangoView.vue
@@ -23,6 +23,7 @@ import {
   type Constraint,
   type Grid,
 } from '@/services/tango'
+import { findHint, symbolName, type Hint } from '@/services/tangoHints'
 
 const { el: boardEl, px: boardPx } = useSquareFit(170)
 const cell = computed(() => boardPx.value / SIZE)
@@ -36,6 +37,34 @@ const given = ref<boolean[]>([])
 const solution = ref<Grid>([])
 const constraints = ref<Constraint[]>([])
 const snackbar = ref(false)
+
+// Progressive hint state: level 0 = idle, 1 = region shown, 2 = exact cell shown,
+// 3 = value revealed (then it resets). The hint is computed once when it starts
+// and held steady across levels; any board change clears it.
+const hint = ref<Hint | null>(null)
+const hintLevel = ref(0)
+const noHint = ref(false)
+
+const clearHint = () => {
+  hint.value = null
+  hintLevel.value = 0
+  noHint.value = false
+}
+
+const hintRegion = computed(() =>
+  hint.value && hintLevel.value >= 1 ? new Set(hint.value.region.concat(hint.value.because)) : new Set<number>(),
+)
+const hintCell = computed(() => (hint.value && hintLevel.value >= 2 ? hint.value.cell : null))
+
+const hintMessage = computed(() => {
+  if (noHint.value) return 'No single-step deduction from here — try filling in what you know, then ask again.'
+  const h = hint.value
+  if (!h) return ''
+  if (hintLevel.value === 1) return `${h.reason} (Hint again to pinpoint the cell.)`
+  if (hintLevel.value === 2) return 'This exact cell is forced. Hint again to reveal its value.'
+  if (hintLevel.value >= 3) return `${h.reason.split(':')[0]}: this cell must be a ${symbolName(h.value)}.`
+  return ''
+})
 
 const conflicts = computed(() => findConflicts(cells.value, constraints.value))
 const solved = computed(() => cells.value.length > 0 && isSolved(cells.value, constraints.value))
@@ -57,6 +86,7 @@ const build = () => {
   given.value = puzzle.given.map((v) => v !== EMPTY)
   solution.value = puzzle.solution.slice()
   constraints.value = puzzle.constraints
+  clearHint()
 }
 
 const syncUrl = () => router.replace({ name: 'tango', params: { seed: code.value } })
@@ -71,6 +101,35 @@ const cycle = (i: number) => {
   const next = cells.value.slice()
   next[i] = next[i] === EMPTY ? SUN : next[i] === SUN ? MOON : EMPTY
   cells.value = next
+  clearHint() // the board changed — any pending hint is stale
+}
+
+// Step the hint through its reveal levels: compute on first press, then
+// region → cell → value; the final step fills the forced cell.
+const nextHint = () => {
+  if (solved.value) return
+  if (!hint.value) {
+    const found = findHint(cells.value, constraints.value)
+    if (!found) {
+      noHint.value = true
+      return
+    }
+    hint.value = found
+    hintLevel.value = 1
+    return
+  }
+  if (hintLevel.value < 3) {
+    hintLevel.value += 1
+    if (hintLevel.value === 3) {
+      const next = cells.value.slice()
+      next[hint.value.cell] = hint.value.value
+      cells.value = next // fill applied without clearHint so the reveal message stays
+    }
+    return
+  }
+  // Level 3 already shown — move on to the next deduction.
+  clearHint()
+  nextHint()
 }
 
 const share = async () => {
@@ -92,6 +151,8 @@ onMounted(() => {
 const cellClass = (i: number) => ({
   'tcell--given': given.value[i],
   'tcell--conflict': conflicts.value.has(i),
+  'tcell--hint-region': hintRegion.value.has(i) && hintCell.value !== i,
+  'tcell--hint-cell': hintCell.value === i,
 })
 </script>
 
@@ -123,13 +184,20 @@ const cellClass = (i: number) => ({
       </template>
     </GameToolbar>
 
-    <div class="d-flex align-center ga-3 mb-3">
+    <div class="d-flex align-center ga-2 mb-3">
       <v-spacer />
+      <v-btn variant="tonal" prepend-icon="mdi-lightbulb-on-outline" :disabled="solved" @click="nextHint">Hint</v-btn>
       <v-btn variant="tonal" color="primary" prepend-icon="mdi-refresh" @click="newGame">New</v-btn>
     </div>
 
     <div ref="boardEl" class="board-wrap" :style="{ width: boardPx + 'px', height: boardPx + 'px' }">
-      <div class="board" :style="{ gridTemplateColumns: `repeat(${SIZE}, 1fr)` }">
+      <div
+        class="board"
+        :style="{
+          gridTemplateColumns: `repeat(${SIZE}, 1fr)`,
+          gridTemplateRows: `repeat(${SIZE}, 1fr)`,
+        }"
+      >
         <button
           v-for="(v, i) in cells"
           :key="i"
@@ -158,6 +226,15 @@ const cellClass = (i: number) => ({
       </div>
     </div>
 
+    <v-alert
+      v-if="hintMessage"
+      class="mt-4"
+      density="comfortable"
+      variant="tonal"
+      :color="noHint ? 'warning' : 'info'"
+      icon="mdi-lightbulb-on-outline"
+    >{{ hintMessage }}</v-alert>
+
     <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Puzzle link copied — share it!</v-snackbar>
   </v-container>
 </template>
@@ -179,6 +256,12 @@ const cellClass = (i: number) => ({
   user-select: none;
 }
 .tcell {
+  /* Square cells: the 6×6 grid tracks (1fr rows + columns inside a square wrapper)
+     already size each cell to boardPx/6; aspect-ratio keeps them square even if a
+     browser lays the tracks out early, before the wrapper's height is applied. */
+  aspect-ratio: 1;
+  min-width: 0;
+  min-height: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -193,6 +276,13 @@ const cellClass = (i: number) => ({
 }
 .tcell--conflict {
   background: rgba(248, 113, 113, 0.22);
+}
+.tcell--hint-region {
+  background: rgba(59, 130, 246, 0.16);
+}
+.tcell--hint-cell {
+  background: rgba(59, 130, 246, 0.42);
+  box-shadow: inset 0 0 0 2px #60a5fa;
 }
 .sun {
   color: #facc15;

--- a/src/views/TetrisView.vue
+++ b/src/views/TetrisView.vue
@@ -19,6 +19,7 @@ import {
   createBag,
   dropRow,
   emptyBoard,
+  fullRows,
   gravityMs,
   lineScore,
   matrixFor,
@@ -51,6 +52,18 @@ const best = ref(0)
 const state = ref<'idle' | 'running' | 'paused' | 'over'>('idle')
 
 let timer: ReturnType<typeof setInterval> | null = null
+
+// Line-clear animation: full rows flash briefly before they collapse away. This
+// is purely a view concern — the pure clear happens in clearLines once the flash
+// finishes. `clearingRows` holds the rows currently flashing.
+const CLEAR_ANIM_MS = 320
+const clearingRows = ref<number[]>([])
+let clearTimer: ReturnType<typeof setTimeout> | null = null
+const cancelClear = () => {
+  if (clearTimer) clearTimeout(clearTimer)
+  clearTimer = null
+  clearingRows.value = []
+}
 
 // Lock delay: a grounded piece doesn't lock instantly — it gets a short grace
 // window so it can be slid or rotated into a gap. Moves reset the window a
@@ -96,15 +109,21 @@ const bumpLock = () => {
 
 // Rendered board = settled cells + ghost landing spot + the active piece.
 const view = computed(() => {
-  const cells = board.value.map((color) => ({ color, ghost: false }))
+  const flashing = new Set(clearingRows.value)
+  const cells = board.value.map((color, i) => ({
+    color,
+    ghost: false,
+    clearing: flashing.has(Math.floor(i / COLS)),
+  }))
   const piece = current.value
   if (piece && (state.value === 'running' || state.value === 'paused')) {
     for (const { x, y } of pieceCells(dropRow(board.value, piece))) {
-      if (y >= 0 && !cells[y * COLS + x].color) cells[y * COLS + x] = { color: 0, ghost: true }
+      if (y >= 0 && !cells[y * COLS + x].color)
+        cells[y * COLS + x] = { color: 0, ghost: true, clearing: false }
     }
     const color = colorOf(piece.type)
     for (const { x, y } of pieceCells(piece)) {
-      if (y >= 0) cells[y * COLS + x] = { color, ghost: false }
+      if (y >= 0) cells[y * COLS + x] = { color, ghost: false, clearing: false }
     }
   }
   return cells
@@ -127,6 +146,10 @@ const previewCells = (type: PieceType | null): number[] => {
 }
 
 const nextPreviews = computed(() => queue.value.slice(0, 3))
+
+// Progress within the current level: you advance a level every 10 lines.
+const linesToNext = computed(() => 10 - (lines.value % 10))
+const levelProgress = computed(() => (lines.value % 10) * 10)
 
 const stopTimer = () => {
   if (timer) clearInterval(timer)
@@ -154,22 +177,41 @@ const spawnNext = () => {
   canHold.value = true
 }
 
+// Settle the score/level for a clear of `n` rows.
+const applyClear = (n: number) => {
+  score.value += lineScore(n, level.value)
+  lines.value += n
+  const nextLevel = Math.floor(lines.value / 10) + 1
+  if (nextLevel !== level.value) {
+    level.value = nextLevel
+    restartGravity() // faster gravity at the new level
+  }
+}
+
 const lockPiece = () => {
   if (!current.value) return
   clearLock()
-  const { board: cleared, cleared: n } = clearLines(merge(board.value, current.value))
-  board.value = cleared
-  if (n > 0) {
-    score.value += lineScore(n, level.value)
-    lines.value += n
-    const nextLevel = Math.floor(lines.value / 10) + 1
-    if (nextLevel !== level.value) {
-      level.value = nextLevel
-      restartGravity() // faster gravity at the new level
-    }
-  }
+  const merged = merge(board.value, current.value)
   current.value = null
-  spawnNext()
+  const full = fullRows(merged)
+  if (full.length === 0) {
+    board.value = merged
+    spawnNext()
+    return
+  }
+  // Show the completed rows, flash them, then collapse. Gravity pauses during
+  // the flash so nothing spawns on top of the animating board.
+  board.value = merged
+  clearingRows.value = full
+  applyClear(full.length)
+  stopTimer() // keep gravity paused through the flash, even after a level-up
+  clearTimer = setTimeout(() => {
+    clearTimer = null
+    clearingRows.value = []
+    board.value = clearLines(merged).board
+    spawnNext()
+    if (state.value === 'running') restartGravity()
+  }, CLEAR_ANIM_MS)
 }
 
 const tick = () => {
@@ -250,6 +292,7 @@ const gameOver = () => {
   state.value = 'over'
   stopTimer()
   clearLock()
+  cancelClear()
   current.value = null
   persistBest()
 }
@@ -257,6 +300,7 @@ const gameOver = () => {
 const reset = () => {
   stopTimer()
   clearLock()
+  cancelClear()
   board.value = emptyBoard()
   queue.value = []
   holdType.value = null
@@ -392,6 +436,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   stopTimer()
   clearLock()
+  cancelClear()
   persistBest()
   window.removeEventListener('keydown', onKey)
 })
@@ -402,7 +447,8 @@ onBeforeUnmount(() => {
     <GameToolbar title="Tetris" shareable @share="share">
       <template #intro>
         Move with arrows / WASD, rotate with up (Z for the other way), hard-drop with Space, hold
-        with C. On mobile, use the buttons or swipe. Clear lines to score; it speeds up each level.
+        with C. On mobile, use the buttons or swipe. Clear lines to score. Every 10 lines you level
+        up: pieces fall faster and each line clear is worth more points.
       </template>
       <template #info>
         <h3>Goal</h3>
@@ -415,8 +461,9 @@ onBeforeUnmount(() => {
           <li><span class="k">C</span> — hold a piece for later. <span class="k">P</span> — pause.</li>
           <li>Mobile: on-screen buttons, or swipe to move / flick down to drop / tap to rotate.</li>
         </ul>
-        <h3>Scoring</h3>
-        <p>1/2/3/4 lines score 100/300/500/800 × level. Soft drop +1 per row, hard drop +2. You level up every 10 lines.</p>
+        <h3>Scoring &amp; levels</h3>
+        <p>1/2/3/4 lines score 100/300/500/800 × level. Soft drop +1 per row, hard drop +2.</p>
+        <p>Every 10 lines you gain a level. Higher levels are a bonus, not just a challenge: pieces fall faster <em>and</em> every line clear is multiplied by your level, so the same tetris is worth far more later on. The bar under the stats shows your progress to the next level.</p>
         <h3>Tips</h3>
         <ul>
           <li>Keep the stack low and flat; leave one column open for I-pieces to score tetrises.</li>
@@ -426,13 +473,21 @@ onBeforeUnmount(() => {
     </GameToolbar>
 
     <!-- Stats -->
-    <div class="d-flex align-center ga-3 mb-3 flex-wrap">
+    <div class="d-flex align-center ga-3 mb-2 flex-wrap">
       <div class="stat"><span class="stat-label">Score</span><span class="stat-value">{{ score }}</span></div>
       <div class="stat"><span class="stat-label">Lines</span><span class="stat-value">{{ lines }}</span></div>
       <div class="stat"><span class="stat-label">Level</span><span class="stat-value">{{ level }}</span></div>
       <v-spacer />
       <div class="text-body-2 text-medium-emphasis">Best: {{ best }}</div>
       <v-btn variant="tonal" color="primary" prepend-icon="mdi-restart" @click="newGame">New</v-btn>
+    </div>
+
+    <!-- Level progress: faster fall + higher line scores at the next level. -->
+    <div class="level-progress mb-3">
+      <v-progress-linear :model-value="levelProgress" color="primary" height="6" rounded />
+      <span class="level-progress-label text-caption text-medium-emphasis">
+        {{ linesToNext }} more {{ linesToNext === 1 ? 'line' : 'lines' }} to level {{ level + 1 }} (faster fall, bigger scores)
+      </span>
     </div>
 
     <div class="play-area">
@@ -448,7 +503,10 @@ onBeforeUnmount(() => {
             v-for="(c, i) in view"
             :key="i"
             class="cell"
-            :class="[c.color ? `cell--${c.color}` : '', { 'cell--ghost': c.ghost }]"
+            :class="[
+              c.color ? `cell--${c.color}` : '',
+              { 'cell--ghost': c.ghost, 'cell--clearing': c.clearing },
+            ]"
           />
         </div>
 
@@ -466,43 +524,71 @@ onBeforeUnmount(() => {
             <p class="text-body-2 mb-3">
               Score {{ score }}<span v-if="score === best && score > 0"> — new best!</span>
             </p>
-            <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="newGame">Play again</v-btn>
+            <div class="d-flex ga-2">
+              <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="newGame">Play again</v-btn>
+              <v-btn color="secondary" variant="tonal" prepend-icon="mdi-share-variant" @click="share">Share</v-btn>
+            </div>
           </template>
         </div>
       </div>
 
-      <!-- Side panel: hold + next -->
+      <!-- Side panel: hold + next. A compact strip above the board on narrow
+           screens, a column beside it on wide ones — always visible. -->
       <div class="side">
-        <div class="side-label">Hold</div>
-        <div class="mini">
-          <div
-            v-for="(c, i) in previewCells(holdType)"
-            :key="'h' + i"
-            class="mini-cell"
-            :class="c ? `cell--${c}` : ''"
-          />
+        <div class="side-group">
+          <div class="side-label">Hold</div>
+          <div class="mini">
+            <div
+              v-for="(c, i) in previewCells(holdType)"
+              :key="'h' + i"
+              class="mini-cell"
+              :class="c ? `cell--${c}` : ''"
+            />
+          </div>
         </div>
-        <div class="side-label mt-3">Next</div>
-        <div v-for="(t, n) in nextPreviews" :key="'n' + n" class="mini">
-          <div
-            v-for="(c, i) in previewCells(t)"
-            :key="i"
-            class="mini-cell"
-            :class="c ? `cell--${c}` : ''"
-          />
+        <div class="side-group side-next">
+          <div class="side-label">Next</div>
+          <div class="mini-row">
+            <div v-for="(t, n) in nextPreviews" :key="'n' + n" class="mini">
+              <div
+                v-for="(c, i) in previewCells(t)"
+                :key="i"
+                class="mini-cell"
+                :class="c ? `cell--${c}` : ''"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- On-screen controls -->
+    <!-- On-screen controls. Hard-drop stays on Space / a downward swipe to keep
+         this row simple — one clear down control that soft-drops. -->
     <div class="controls mt-4">
-      <v-btn icon="mdi-rotate-right-variant" variant="tonal" @click="rotatePiece(1)" />
-      <v-btn icon="mdi-chevron-left" variant="tonal" @click="tryMove(-1)" />
-      <v-btn icon="mdi-chevron-down" variant="tonal" @click="softDrop" />
-      <v-btn icon="mdi-chevron-right" variant="tonal" @click="tryMove(1)" />
-      <v-btn icon="mdi-arrow-collapse-down" variant="tonal" @click="hardDrop" />
-      <v-btn icon="mdi-tray-arrow-up" variant="tonal" :disabled="!canHold" @click="hold" />
-      <v-btn :icon="state === 'paused' ? 'mdi-play' : 'mdi-pause'" variant="tonal" @click="togglePause" />
+      <v-btn icon variant="tonal" @click="rotatePiece(1)">
+        <v-icon icon="mdi-rotate-right-variant" />
+        <v-tooltip activator="parent" location="top" text="Rotate" />
+      </v-btn>
+      <v-btn icon variant="tonal" @click="tryMove(-1)">
+        <v-icon icon="mdi-chevron-left" />
+        <v-tooltip activator="parent" location="top" text="Move left" />
+      </v-btn>
+      <v-btn icon variant="tonal" @click="softDrop">
+        <v-icon icon="mdi-chevron-down" />
+        <v-tooltip activator="parent" location="top" text="Soft drop (Space or swipe down to hard-drop)" />
+      </v-btn>
+      <v-btn icon variant="tonal" @click="tryMove(1)">
+        <v-icon icon="mdi-chevron-right" />
+        <v-tooltip activator="parent" location="top" text="Move right" />
+      </v-btn>
+      <v-btn icon variant="tonal" :disabled="!canHold" @click="hold">
+        <v-icon icon="mdi-archive-arrow-down-outline" />
+        <v-tooltip activator="parent" location="top" text="Hold piece" />
+      </v-btn>
+      <v-btn icon variant="tonal" @click="togglePause">
+        <v-icon :icon="state === 'paused' ? 'mdi-play' : 'mdi-pause'" />
+        <v-tooltip activator="parent" location="top" :text="state === 'paused' ? 'Resume' : 'Pause'" />
+      </v-btn>
     </div>
 
     <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Score copied — challenge a friend!</v-snackbar>
@@ -510,10 +596,13 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
+/* Mobile-first: stack the hold/next strip above the board so it's never pushed
+   off-screen. Wide screens move it beside the board (see the media query). */
 .play-area {
   display: flex;
-  gap: 14px;
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
   justify-content: center;
 }
 
@@ -544,6 +633,33 @@ onBeforeUnmount(() => {
   background: rgba(226, 232, 240, 0.16);
   box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.25);
 }
+/* Completed rows flash bright, then the row collapses just before it clears. */
+.cell--clearing {
+  animation: line-clear 320ms ease-out forwards;
+  z-index: 1;
+}
+@keyframes line-clear {
+  0% {
+    filter: brightness(1);
+    transform: scale(1);
+  }
+  35% {
+    background: #fff;
+    filter: brightness(2.4);
+    transform: scale(1.08);
+  }
+  100% {
+    background: #fff;
+    filter: brightness(3);
+    transform: scaleY(0);
+    opacity: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cell--clearing {
+    animation-duration: 1ms;
+  }
+}
 
 /* Piece colors, in COLOR_ORDER: I O T S Z J L */
 .cell--1 { background: #22d3ee; } /* I - cyan */
@@ -554,9 +670,20 @@ onBeforeUnmount(() => {
 .cell--6 { background: #3b82f6; } /* J - blue */
 .cell--7 { background: #f97316; } /* L - orange */
 
+/* Narrow: a horizontal strip of Hold + Next groups above the board. */
 .side {
   flex: 0 0 auto;
-  min-width: 76px;
+  order: -1;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.side-group {
+  display: flex;
+  flex-direction: column;
 }
 .side-label {
   font-size: 0.7rem;
@@ -565,17 +692,50 @@ onBeforeUnmount(() => {
   color: rgba(148, 163, 184, 0.9);
   margin-bottom: 4px;
 }
+.mini-row {
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+}
 .mini {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 2px;
-  width: 68px;
+  width: 56px;
   aspect-ratio: 1;
-  margin-bottom: 6px;
 }
 .mini-cell {
   border-radius: 2px;
   background: rgba(148, 163, 184, 0.05);
+}
+
+.level-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+/* Wide: hold/next sits in a column beside the board, next pieces stacked. */
+@media (min-width: 640px) {
+  .play-area {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 14px;
+  }
+  .side {
+    order: 0;
+    flex-direction: column;
+    justify-content: flex-start;
+    gap: 12px;
+    min-width: 76px;
+  }
+  .mini-row {
+    flex-direction: column;
+    gap: 6px;
+  }
+  .mini {
+    width: 68px;
+  }
 }
 
 .stat {

--- a/src/views/TetrisView.vue
+++ b/src/views/TetrisView.vue
@@ -52,7 +52,47 @@ const state = ref<'idle' | 'running' | 'paused' | 'over'>('idle')
 
 let timer: ReturnType<typeof setInterval> | null = null
 
+// Lock delay: a grounded piece doesn't lock instantly — it gets a short grace
+// window so it can be slid or rotated into a gap. Moves reset the window a
+// capped number of times so it can't be stalled forever.
+const LOCK_DELAY = 500
+const MAX_LOCK_RESETS = 15
+let lockTimer: ReturnType<typeof setTimeout> | null = null
+let lockResets = 0
+
 const colorOf = (type: PieceType) => COLOR_ORDER.indexOf(type) + 1
+
+const grounded = (): boolean =>
+  !!current.value && collides(board.value, { ...current.value, y: current.value.y + 1 })
+
+const clearLock = () => {
+  if (lockTimer) clearTimeout(lockTimer)
+  lockTimer = null
+  lockResets = 0
+}
+
+const scheduleLock = () => {
+  if (lockTimer) return
+  lockTimer = setTimeout(() => {
+    lockTimer = null
+    lockResets = 0
+    if (grounded()) lockPiece()
+  }, LOCK_DELAY)
+}
+
+// Called after a manual move/rotate: cancel the lock if the piece can now fall,
+// otherwise extend the grace window (up to the reset cap).
+const bumpLock = () => {
+  if (!lockTimer) return
+  if (!grounded()) {
+    clearLock()
+  } else if (lockResets < MAX_LOCK_RESETS) {
+    lockResets += 1
+    clearTimeout(lockTimer)
+    lockTimer = null
+    scheduleLock()
+  }
+}
 
 // Rendered board = settled cells + ghost landing spot + the active piece.
 const view = computed(() => {
@@ -116,6 +156,7 @@ const spawnNext = () => {
 
 const lockPiece = () => {
   if (!current.value) return
+  clearLock()
   const { board: cleared, cleared: n } = clearLines(merge(board.value, current.value))
   board.value = cleared
   if (n > 0) {
@@ -134,21 +175,24 @@ const lockPiece = () => {
 const tick = () => {
   if (state.value !== 'running' || !current.value) return
   const moved = { ...current.value, y: current.value.y + 1 }
-  if (collides(board.value, moved)) lockPiece()
+  if (collides(board.value, moved)) scheduleLock()
   else current.value = moved
 }
 
 const tryMove = (dx: number) => {
   if (state.value !== 'running' || !current.value) return
   const moved = { ...current.value, x: current.value.x + dx }
-  if (!collides(board.value, moved)) current.value = moved
+  if (!collides(board.value, moved)) {
+    current.value = moved
+    bumpLock()
+  }
 }
 
 const softDrop = () => {
   if (state.value !== 'running' || !current.value) return
   const moved = { ...current.value, y: current.value.y + 1 }
   if (collides(board.value, moved)) {
-    lockPiece()
+    scheduleLock()
   } else {
     current.value = moved
     score.value += 1
@@ -158,7 +202,10 @@ const softDrop = () => {
 const rotatePiece = (dir: 1 | -1) => {
   if (state.value !== 'running' || !current.value) return
   const rotated = rotate(board.value, current.value, dir)
-  if (rotated) current.value = rotated
+  if (rotated) {
+    current.value = rotated
+    bumpLock()
+  }
 }
 
 const hardDrop = () => {
@@ -202,12 +249,14 @@ const persistBest = () => {
 const gameOver = () => {
   state.value = 'over'
   stopTimer()
+  clearLock()
   current.value = null
   persistBest()
 }
 
 const reset = () => {
   stopTimer()
+  clearLock()
   board.value = emptyBoard()
   queue.value = []
   holdType.value = null
@@ -235,6 +284,7 @@ const togglePause = () => {
   if (state.value === 'running') {
     state.value = 'paused'
     stopTimer()
+    clearLock()
   } else if (state.value === 'paused') {
     start()
   }
@@ -245,7 +295,11 @@ const newGame = () => {
   start()
 }
 
+// Actions that must fire once per physical press, not on OS key auto-repeat.
+const NO_REPEAT = new Set([' ', 'ArrowUp', 'x', 'X', 'z', 'Z', 'c', 'C', 'p', 'P'])
+
 const onKey = (e: KeyboardEvent) => {
+  if (e.repeat && NO_REPEAT.has(e.key)) return
   switch (e.key) {
     case 'ArrowLeft':
     case 'a':
@@ -307,7 +361,7 @@ const onTouchEnd = (e: TouchEvent) => {
   const dy = t.clientY - touchStart.y
   const start0 = touchStart
   touchStart = null
-  if (Math.abs(dx) < 20 && Math.abs(dy) < 20 && e.timeStamp - start0.t < 250) {
+  if (Math.abs(dx) < 12 && Math.abs(dy) < 12 && e.timeStamp - start0.t < 250) {
     rotatePiece(1)
     return
   }
@@ -337,6 +391,7 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   stopTimer()
+  clearLock()
   persistBest()
   window.removeEventListener('keydown', onKey)
 })

--- a/src/views/TetrisView.vue
+++ b/src/views/TetrisView.vue
@@ -1,0 +1,564 @@
+<script setup lang="ts">
+/**
+ * Tetris — the falling-blocks classic. Arrows / WASD to move & soft-drop, up (or
+ * X) to rotate, Z for counter-clockwise, Space to hard-drop, C to hold, P to
+ * pause; on-screen buttons and swipe mirror these on mobile. Ghost piece, 7-bag
+ * randomizer, hold slot, next queue, level speed-up, and a saved best score.
+ * Core rules live in services/tetris.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { copyToClipboard } from '@/services/share'
+import { useSquareFit } from '@/composables/useSquareFit'
+import {
+  COLS,
+  COLOR_ORDER,
+  ROWS,
+  clearLines,
+  collides,
+  createBag,
+  dropRow,
+  emptyBoard,
+  gravityMs,
+  lineScore,
+  matrixFor,
+  merge,
+  pieceCells,
+  rotate,
+  spawnPiece,
+  type Board,
+  type Piece,
+  type PieceType,
+} from '@/services/tetris'
+
+const { el: boardEl, px: boardPx } = useSquareFit(160)
+// The board is twice as tall as wide; fit it inside the measured square.
+const cell = computed(() => boardPx.value / ROWS)
+const boardWidth = computed(() => cell.value * COLS)
+
+const BEST_KEY = 'tetris-best'
+const rng = Math.random
+
+const board = ref<Board>(emptyBoard())
+const current = ref<Piece | null>(null)
+const queue = ref<PieceType[]>([])
+const holdType = ref<PieceType | null>(null)
+const canHold = ref(true)
+const score = ref(0)
+const lines = ref(0)
+const level = ref(1)
+const best = ref(0)
+const state = ref<'idle' | 'running' | 'paused' | 'over'>('idle')
+
+let timer: ReturnType<typeof setInterval> | null = null
+
+const colorOf = (type: PieceType) => COLOR_ORDER.indexOf(type) + 1
+
+// Rendered board = settled cells + ghost landing spot + the active piece.
+const view = computed(() => {
+  const cells = board.value.map((color) => ({ color, ghost: false }))
+  const piece = current.value
+  if (piece && (state.value === 'running' || state.value === 'paused')) {
+    for (const { x, y } of pieceCells(dropRow(board.value, piece))) {
+      if (y >= 0 && !cells[y * COLS + x].color) cells[y * COLS + x] = { color: 0, ghost: true }
+    }
+    const color = colorOf(piece.type)
+    for (const { x, y } of pieceCells(piece)) {
+      if (y >= 0) cells[y * COLS + x] = { color, ghost: false }
+    }
+  }
+  return cells
+})
+
+/** A 4×4 preview grid (color indices) for the hold/next slots. */
+const previewCells = (type: PieceType | null): number[] => {
+  const grid = Array<number>(16).fill(0)
+  if (!type) return grid
+  const m = matrixFor(type, 0)
+  const color = colorOf(type)
+  const offR = Math.floor((4 - m.length) / 2)
+  const offC = Math.floor((4 - m[0].length) / 2)
+  for (let r = 0; r < m.length; r += 1) {
+    for (let c = 0; c < m[r].length; c += 1) {
+      if (m[r][c]) grid[(r + offR) * 4 + (c + offC)] = color
+    }
+  }
+  return grid
+}
+
+const nextPreviews = computed(() => queue.value.slice(0, 3))
+
+const stopTimer = () => {
+  if (timer) clearInterval(timer)
+  timer = null
+}
+const restartGravity = () => {
+  stopTimer()
+  if (state.value === 'running') timer = setInterval(tick, gravityMs(level.value))
+}
+
+const pullNext = (): PieceType => {
+  if (queue.value.length <= 7) queue.value = [...queue.value, ...createBag(rng)]
+  const [next, ...rest] = queue.value
+  queue.value = rest
+  return next
+}
+
+const spawnNext = () => {
+  const piece = spawnPiece(pullNext())
+  if (collides(board.value, piece)) {
+    gameOver()
+    return
+  }
+  current.value = piece
+  canHold.value = true
+}
+
+const lockPiece = () => {
+  if (!current.value) return
+  const { board: cleared, cleared: n } = clearLines(merge(board.value, current.value))
+  board.value = cleared
+  if (n > 0) {
+    score.value += lineScore(n, level.value)
+    lines.value += n
+    const nextLevel = Math.floor(lines.value / 10) + 1
+    if (nextLevel !== level.value) {
+      level.value = nextLevel
+      restartGravity() // faster gravity at the new level
+    }
+  }
+  current.value = null
+  spawnNext()
+}
+
+const tick = () => {
+  if (state.value !== 'running' || !current.value) return
+  const moved = { ...current.value, y: current.value.y + 1 }
+  if (collides(board.value, moved)) lockPiece()
+  else current.value = moved
+}
+
+const tryMove = (dx: number) => {
+  if (state.value !== 'running' || !current.value) return
+  const moved = { ...current.value, x: current.value.x + dx }
+  if (!collides(board.value, moved)) current.value = moved
+}
+
+const softDrop = () => {
+  if (state.value !== 'running' || !current.value) return
+  const moved = { ...current.value, y: current.value.y + 1 }
+  if (collides(board.value, moved)) {
+    lockPiece()
+  } else {
+    current.value = moved
+    score.value += 1
+  }
+}
+
+const rotatePiece = (dir: 1 | -1) => {
+  if (state.value !== 'running' || !current.value) return
+  const rotated = rotate(board.value, current.value, dir)
+  if (rotated) current.value = rotated
+}
+
+const hardDrop = () => {
+  if (state.value !== 'running' || !current.value) return
+  const landed = dropRow(board.value, current.value)
+  score.value += (landed.y - current.value.y) * 2
+  current.value = landed
+  lockPiece()
+}
+
+const hold = () => {
+  if (state.value !== 'running' || !current.value || !canHold.value) return
+  const currentType = current.value.type
+  if (holdType.value) {
+    const piece = spawnPiece(holdType.value)
+    holdType.value = currentType
+    if (collides(board.value, piece)) {
+      gameOver()
+      return
+    }
+    current.value = piece
+  } else {
+    holdType.value = currentType
+    current.value = null
+    spawnNext()
+  }
+  canHold.value = false
+}
+
+const persistBest = () => {
+  if (score.value > best.value) {
+    best.value = score.value
+    try {
+      localStorage.setItem(BEST_KEY, String(best.value))
+    } catch {
+      // ignore storage errors
+    }
+  }
+}
+
+const gameOver = () => {
+  state.value = 'over'
+  stopTimer()
+  current.value = null
+  persistBest()
+}
+
+const reset = () => {
+  stopTimer()
+  board.value = emptyBoard()
+  queue.value = []
+  holdType.value = null
+  canHold.value = true
+  score.value = 0
+  lines.value = 0
+  level.value = 1
+  current.value = null
+  state.value = 'idle'
+}
+
+const start = () => {
+  if (state.value === 'idle' || state.value === 'over') {
+    if (state.value === 'over') reset()
+    state.value = 'running'
+    spawnNext()
+    restartGravity()
+  } else if (state.value === 'paused') {
+    state.value = 'running'
+    restartGravity()
+  }
+}
+
+const togglePause = () => {
+  if (state.value === 'running') {
+    state.value = 'paused'
+    stopTimer()
+  } else if (state.value === 'paused') {
+    start()
+  }
+}
+
+const newGame = () => {
+  reset()
+  start()
+}
+
+const onKey = (e: KeyboardEvent) => {
+  switch (e.key) {
+    case 'ArrowLeft':
+    case 'a':
+    case 'A':
+      e.preventDefault()
+      tryMove(-1)
+      break
+    case 'ArrowRight':
+    case 'd':
+    case 'D':
+      e.preventDefault()
+      tryMove(1)
+      break
+    case 'ArrowDown':
+    case 's':
+    case 'S':
+      e.preventDefault()
+      softDrop()
+      break
+    case 'ArrowUp':
+    case 'x':
+    case 'X':
+      e.preventDefault()
+      rotatePiece(1)
+      break
+    case 'z':
+    case 'Z':
+      e.preventDefault()
+      rotatePiece(-1)
+      break
+    case ' ':
+      e.preventDefault()
+      if (state.value === 'running') hardDrop()
+      else start()
+      break
+    case 'c':
+    case 'C':
+      e.preventDefault()
+      hold()
+      break
+    case 'p':
+    case 'P':
+      e.preventDefault()
+      togglePause()
+      break
+  }
+}
+
+// Swipe: horizontal drag moves, a downward flick hard-drops, a tap rotates.
+let touchStart: { x: number; y: number; t: number } | null = null
+const onTouchStart = (e: TouchEvent) => {
+  const t = e.changedTouches[0]
+  touchStart = { x: t.clientX, y: t.clientY, t: e.timeStamp }
+}
+const onTouchEnd = (e: TouchEvent) => {
+  if (!touchStart) return
+  const t = e.changedTouches[0]
+  const dx = t.clientX - touchStart.x
+  const dy = t.clientY - touchStart.y
+  const start0 = touchStart
+  touchStart = null
+  if (Math.abs(dx) < 20 && Math.abs(dy) < 20 && e.timeStamp - start0.t < 250) {
+    rotatePiece(1)
+    return
+  }
+  if (Math.abs(dx) > Math.abs(dy)) {
+    const steps = Math.round(dx / Math.max(cell.value, 1))
+    for (let i = 0; i < Math.abs(steps); i += 1) tryMove(Math.sign(steps))
+  } else if (dy > 24) {
+    hardDrop()
+  }
+}
+
+const snackbar = ref(false)
+const share = async () => {
+  const url = window.location.origin + '/tetris'
+  await copyToClipboard(`I scored ${score.value} in Tetris (level ${level.value}, ${lines.value} lines). Beat me!\n${url}`)
+  snackbar.value = true
+}
+
+onMounted(() => {
+  try {
+    best.value = Number(localStorage.getItem(BEST_KEY)) || 0
+  } catch {
+    best.value = 0
+  }
+  reset()
+  window.addEventListener('keydown', onKey)
+})
+onBeforeUnmount(() => {
+  stopTimer()
+  persistBest()
+  window.removeEventListener('keydown', onKey)
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="720">
+    <GameToolbar title="Tetris" shareable @share="share">
+      <template #intro>
+        Move with arrows / WASD, rotate with up (Z for the other way), hard-drop with Space, hold
+        with C. On mobile, use the buttons or swipe. Clear lines to score; it speeds up each level.
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Stack the falling tetrominoes to complete horizontal lines, which then clear. Clear four at once — a "tetris" — for the most points.</p>
+        <h3>Controls</h3>
+        <ul>
+          <li><span class="k">←</span>/<span class="k">→</span> or <span class="k">A</span>/<span class="k">D</span> — move.</li>
+          <li><span class="k">↓</span>/<span class="k">S</span> — soft drop. <span class="k">Space</span> — hard drop.</li>
+          <li><span class="k">↑</span>/<span class="k">X</span> — rotate; <span class="k">Z</span> — rotate the other way.</li>
+          <li><span class="k">C</span> — hold a piece for later. <span class="k">P</span> — pause.</li>
+          <li>Mobile: on-screen buttons, or swipe to move / flick down to drop / tap to rotate.</li>
+        </ul>
+        <h3>Scoring</h3>
+        <p>1/2/3/4 lines score 100/300/500/800 × level. Soft drop +1 per row, hard drop +2. You level up every 10 lines.</p>
+        <h3>Tips</h3>
+        <ul>
+          <li>Keep the stack low and flat; leave one column open for I-pieces to score tetrises.</li>
+          <li>Use hold to stash an awkward piece until it fits.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <!-- Stats -->
+    <div class="d-flex align-center ga-3 mb-3 flex-wrap">
+      <div class="stat"><span class="stat-label">Score</span><span class="stat-value">{{ score }}</span></div>
+      <div class="stat"><span class="stat-label">Lines</span><span class="stat-value">{{ lines }}</span></div>
+      <div class="stat"><span class="stat-label">Level</span><span class="stat-value">{{ level }}</span></div>
+      <v-spacer />
+      <div class="text-body-2 text-medium-emphasis">Best: {{ best }}</div>
+      <v-btn variant="tonal" color="primary" prepend-icon="mdi-restart" @click="newGame">New</v-btn>
+    </div>
+
+    <div class="play-area">
+      <!-- Board -->
+      <div ref="boardEl" class="board-wrap" :style="{ width: boardWidth + 'px', height: boardPx + 'px' }">
+        <div
+          class="board"
+          :style="{ gridTemplateColumns: `repeat(${COLS}, 1fr)`, gridTemplateRows: `repeat(${ROWS}, 1fr)` }"
+          @touchstart.passive="onTouchStart"
+          @touchend="onTouchEnd"
+        >
+          <div
+            v-for="(c, i) in view"
+            :key="i"
+            class="cell"
+            :class="[c.color ? `cell--${c.color}` : '', { 'cell--ghost': c.ghost }]"
+          />
+        </div>
+
+        <div v-if="state !== 'running'" class="overlay">
+          <template v-if="state === 'idle'">
+            <p class="text-h6 mb-3">Ready?</p>
+            <v-btn color="primary" variant="flat" @click="start">Start</v-btn>
+          </template>
+          <template v-else-if="state === 'paused'">
+            <p class="text-h6 mb-3">Paused</p>
+            <v-btn color="primary" variant="flat" @click="togglePause">Resume</v-btn>
+          </template>
+          <template v-else>
+            <p class="text-h5 mb-1">Game over</p>
+            <p class="text-body-2 mb-3">
+              Score {{ score }}<span v-if="score === best && score > 0"> — new best!</span>
+            </p>
+            <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="newGame">Play again</v-btn>
+          </template>
+        </div>
+      </div>
+
+      <!-- Side panel: hold + next -->
+      <div class="side">
+        <div class="side-label">Hold</div>
+        <div class="mini">
+          <div
+            v-for="(c, i) in previewCells(holdType)"
+            :key="'h' + i"
+            class="mini-cell"
+            :class="c ? `cell--${c}` : ''"
+          />
+        </div>
+        <div class="side-label mt-3">Next</div>
+        <div v-for="(t, n) in nextPreviews" :key="'n' + n" class="mini">
+          <div
+            v-for="(c, i) in previewCells(t)"
+            :key="i"
+            class="mini-cell"
+            :class="c ? `cell--${c}` : ''"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- On-screen controls -->
+    <div class="controls mt-4">
+      <v-btn icon="mdi-rotate-right-variant" variant="tonal" @click="rotatePiece(1)" />
+      <v-btn icon="mdi-chevron-left" variant="tonal" @click="tryMove(-1)" />
+      <v-btn icon="mdi-chevron-down" variant="tonal" @click="softDrop" />
+      <v-btn icon="mdi-chevron-right" variant="tonal" @click="tryMove(1)" />
+      <v-btn icon="mdi-arrow-collapse-down" variant="tonal" @click="hardDrop" />
+      <v-btn icon="mdi-tray-arrow-up" variant="tonal" :disabled="!canHold" @click="hold" />
+      <v-btn :icon="state === 'paused' ? 'mdi-play' : 'mdi-pause'" variant="tonal" @click="togglePause" />
+    </div>
+
+    <v-snackbar v-model="snackbar" :timeout="2600" color="secondary">Score copied — challenge a friend!</v-snackbar>
+  </v-container>
+</template>
+
+<style scoped>
+.play-area {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.board-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.board {
+  display: grid;
+  gap: 1px;
+  padding: 4px;
+  width: 100%;
+  height: 100%;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  box-shadow: 0 0 40px rgba(124, 58, 237, 0.18), inset 0 0 40px rgba(124, 58, 237, 0.06);
+  touch-action: none;
+  user-select: none;
+}
+
+.cell {
+  border-radius: 2px;
+  background: rgba(148, 163, 184, 0.05);
+}
+.cell--ghost {
+  background: rgba(226, 232, 240, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.25);
+}
+
+/* Piece colors, in COLOR_ORDER: I O T S Z J L */
+.cell--1 { background: #22d3ee; } /* I - cyan */
+.cell--2 { background: #facc15; } /* O - yellow */
+.cell--3 { background: #a855f7; } /* T - purple */
+.cell--4 { background: #22c55e; } /* S - green */
+.cell--5 { background: #ef4444; } /* Z - red */
+.cell--6 { background: #3b82f6; } /* J - blue */
+.cell--7 { background: #f97316; } /* L - orange */
+
+.side {
+  flex: 0 0 auto;
+  min-width: 76px;
+}
+.side-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.9);
+  margin-bottom: 4px;
+}
+.mini {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2px;
+  width: 68px;
+  aspect-ratio: 1;
+  margin-bottom: 6px;
+}
+.mini-cell {
+  border-radius: 2px;
+  background: rgba(148, 163, 184, 0.05);
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  background: rgba(30, 41, 59, 0.75);
+  border-radius: 8px;
+  padding: 4px 14px;
+  min-width: 72px;
+}
+.stat-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.9);
+}
+.stat-value {
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: rgba(2, 6, 23, 0.78);
+  backdrop-filter: blur(3px);
+  border-radius: 10px;
+}
+
+.controls {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+</style>

--- a/src/views/TunnelView.vue
+++ b/src/views/TunnelView.vue
@@ -5,7 +5,7 @@
  * Hit a wall and it's over. Rendered on a canvas; physics/course come from
  * services/tunnel. Endless, with a best-distance score in localStorage.
  */
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import GameToolbar from '@/components/GameToolbar.vue'
 import { useSquareFit } from '@/composables/useSquareFit'
 import {
@@ -117,7 +117,9 @@ const tick = (ts: number) => {
   distance.value += (scrollSpeed * dt) / 1000
   flyer = stepFlyer(flyer, dt)
 
-  const seg = segmentAt(seed, Math.round(distance.value), difficultyFor(distance.value))
+  // The wall band drawn at the flyer's y is row floor(distance); test that one.
+  const row = Math.floor(distance.value)
+  const seg = segmentAt(seed, row, difficultyFor(row))
   if (collides(flyer.x, seg)) {
     draw()
     gameOver()
@@ -162,6 +164,11 @@ const onKey = (e: KeyboardEvent) => {
     if (state.value !== 'running') start()
   }
 }
+
+// Redraw when the board is resized while not actively animating.
+watch([displayW, displayH], () => {
+  if (state.value !== 'running') draw()
+})
 
 onMounted(() => {
   try {

--- a/src/views/TunnelView.vue
+++ b/src/views/TunnelView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 /**
- * Vertical Tunnel — fly upward through a scrolling, narrowing tunnel. Tap (or
- * arrow-key) the left/right side to flap that way; do nothing and you drift.
+ * Vertical Tunnel — steer a circle up a scrolling, narrowing tunnel. Tap (or
+ * arrow-key) the left/right side to nudge that way; do nothing and you coast.
  * Hit a wall and it's over. Rendered on a canvas; physics/course come from
  * services/tunnel. Endless, with a best-distance score in localStorage.
  */
@@ -13,6 +13,7 @@ import {
   collides,
   difficultyFor,
   flap,
+  scrollSpeedFor,
   segmentAt,
   stepFlyer,
   type FlyerState,
@@ -112,8 +113,7 @@ const tick = (ts: number) => {
   const dt = lastTs ? Math.min(48, ts - lastTs) : 16
   lastTs = ts
 
-  const diff = difficultyFor(distance.value)
-  const scrollSpeed = 2.6 + diff * 2.2 // rows per second
+  const scrollSpeed = scrollSpeedFor(distance.value) // rows per second, ramps up
   distance.value += (scrollSpeed * dt) / 1000
   flyer = stepFlyer(flyer, dt)
 
@@ -190,22 +190,24 @@ onBeforeUnmount(() => {
   <v-container class="py-6" max-width="600">
     <GameToolbar title="Vertical Tunnel">
       <template #intro>
-        Fly up through the tunnel. Tap the <strong>left</strong> or <strong>right</strong> side to
-        flap that way (arrow keys on desktop). Don't drift into the walls — it speeds up as you climb.
+        Steer your circle up the tunnel. Tap a side to nudge that way — the
+        <strong>left</strong> or <strong>right</strong> half of the board (arrow keys on desktop).
+        Keep off the walls as the tunnel weaves, pinches, and picks up speed.
       </template>
       <template #info>
         <h3>Goal</h3>
-        <p>Fly as far up the tunnel as you can without hitting a wall.</p>
+        <p>Steer your circle as far up the tunnel as you can without hitting a wall.</p>
         <h3>Controls</h3>
         <ul>
-          <li>Tap or click the left/right half of the screen to flap left/right.</li>
+          <li>Tap or click the left/right half of the board to thrust that way.</li>
           <li>Desktop: <span class="k">←</span>/<span class="k">→</span> (or A/D). <span class="k">Space</span> to start.</li>
-          <li>Between flaps you keep drifting, then slow — so tap in rhythm to steer.</li>
+          <li>After each nudge you keep coasting, then slow — so tap in rhythm to steer.</li>
         </ul>
         <h3>Tips</h3>
         <ul>
-          <li>Small, frequent taps steer more precisely than one big flap.</li>
-          <li>Look ahead to where the gap is drifting, not where it is now.</li>
+          <li>Small, frequent taps steer more precisely than one hard shove.</li>
+          <li>The corridor breathes — line up early for the tight pinch points.</li>
+          <li>It only gets faster, so look ahead to where the gap is drifting.</li>
         </ul>
       </template>
     </GameToolbar>
@@ -225,8 +227,8 @@ onBeforeUnmount(() => {
       />
       <div v-if="state !== 'running'" class="overlay">
         <template v-if="state === 'idle'">
-          <p class="text-h6 mb-2">Tap to fly</p>
-          <p class="text-caption text-medium-emphasis mb-3">Left/right side flaps that way</p>
+          <p class="text-h6 mb-2">Tap to start</p>
+          <p class="text-caption text-medium-emphasis mb-3">Tap a side to nudge that way</p>
           <v-btn color="primary" variant="flat" @click="start">Start</v-btn>
         </template>
         <template v-else>
@@ -234,7 +236,7 @@ onBeforeUnmount(() => {
           <p class="text-body-2 mb-3">
             Distance {{ score }}<span v-if="score === best && score > 0"> — new best!</span>
           </p>
-          <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="start">Fly again</v-btn>
+          <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="start">Try again</v-btn>
         </template>
       </div>
     </div>

--- a/src/views/TunnelView.vue
+++ b/src/views/TunnelView.vue
@@ -1,0 +1,261 @@
+<script setup lang="ts">
+/**
+ * Vertical Tunnel — fly upward through a scrolling, narrowing tunnel. Tap (or
+ * arrow-key) the left/right side to flap that way; do nothing and you drift.
+ * Hit a wall and it's over. Rendered on a canvas; physics/course come from
+ * services/tunnel. Endless, with a best-distance score in localStorage.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { useSquareFit } from '@/composables/useSquareFit'
+import {
+  FLYER_RADIUS,
+  collides,
+  difficultyFor,
+  flap,
+  segmentAt,
+  stepFlyer,
+  type FlyerState,
+} from '@/services/tunnel'
+
+const { el: boardEl, px: boardPx } = useSquareFit(150)
+const displayW = computed(() => Math.round(boardPx.value * 0.64))
+const displayH = computed(() => boardPx.value)
+
+const BEST_KEY = 'tunnel-best'
+const ROW_FRAC = 0.14 // one course row = 14% of width, in px
+const FLYER_Y_FRAC = 0.72 // flyer's fixed vertical position
+
+const canvasEl = ref<HTMLCanvasElement | null>(null)
+const state = ref<'idle' | 'running' | 'over'>('idle')
+const distance = ref(0)
+const best = ref(0)
+
+let flyer: FlyerState = { x: 0.5, vx: 0 }
+let seed = 1
+let raf = 0
+let lastTs = 0
+
+const score = computed(() => Math.floor(distance.value))
+
+const reset = () => {
+  flyer = { x: 0.5, vx: 0 }
+  distance.value = 0
+  seed = (Math.floor(Math.random() * 0xffffffff) || 1) >>> 0
+}
+
+const gameOver = () => {
+  state.value = 'over'
+  cancelAnimationFrame(raf)
+  raf = 0
+  if (score.value > best.value) {
+    best.value = score.value
+    try {
+      localStorage.setItem(BEST_KEY, String(best.value))
+    } catch {
+      // ignore
+    }
+  }
+}
+
+const draw = () => {
+  const canvas = canvasEl.value
+  if (!canvas) return
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  const dpr = window.devicePixelRatio || 1
+  const W = displayW.value
+  const H = displayH.value
+  if (canvas.width !== W * dpr || canvas.height !== H * dpr) {
+    canvas.width = W * dpr
+    canvas.height = H * dpr
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+  // Background
+  ctx.fillStyle = '#020617'
+  ctx.fillRect(0, 0, W, H)
+
+  const rowPx = W * ROW_FRAC
+  const flyerY = H * FLYER_Y_FRAC
+
+  // Draw wall bands from the bottom of the screen up past the top.
+  const kMin = Math.floor(distance.value - (H - flyerY) / rowPx) - 1
+  const kMax = Math.ceil(distance.value + flyerY / rowPx) + 1
+  for (let k = kMin; k <= kMax; k += 1) {
+    if (k < 0) continue
+    const seg = segmentAt(seed, k, difficultyFor(k))
+    const y = flyerY - (k - distance.value) * rowPx
+    const h = rowPx + 1.5
+    ctx.fillStyle = '#1e293b'
+    ctx.fillRect(0, y - h, seg.left * W, h)
+    ctx.fillRect(seg.right * W, y - h, W - seg.right * W, h)
+    // Edge glow
+    ctx.fillStyle = 'rgba(56, 189, 248, 0.5)'
+    ctx.fillRect(seg.left * W - 2, y - h, 2, h)
+    ctx.fillRect(seg.right * W, y - h, 2, h)
+  }
+
+  // Flyer
+  const fx = flyer.x * W
+  ctx.beginPath()
+  ctx.arc(fx, flyerY, FLYER_RADIUS * W, 0, Math.PI * 2)
+  ctx.fillStyle = '#f472b6'
+  ctx.shadowColor = '#f472b6'
+  ctx.shadowBlur = 16
+  ctx.fill()
+  ctx.shadowBlur = 0
+}
+
+const tick = (ts: number) => {
+  if (state.value !== 'running') return
+  const dt = lastTs ? Math.min(48, ts - lastTs) : 16
+  lastTs = ts
+
+  const diff = difficultyFor(distance.value)
+  const scrollSpeed = 2.6 + diff * 2.2 // rows per second
+  distance.value += (scrollSpeed * dt) / 1000
+  flyer = stepFlyer(flyer, dt)
+
+  const seg = segmentAt(seed, Math.round(distance.value), difficultyFor(distance.value))
+  if (collides(flyer.x, seg)) {
+    draw()
+    gameOver()
+    return
+  }
+  draw()
+  raf = requestAnimationFrame(tick)
+}
+
+const start = () => {
+  reset()
+  state.value = 'running'
+  lastTs = 0
+  cancelAnimationFrame(raf)
+  raf = requestAnimationFrame(tick)
+}
+
+const doFlap = (dir: -1 | 1) => {
+  if (state.value === 'running') flyer = flap(flyer, dir)
+}
+
+const onPointer = (e: PointerEvent) => {
+  if (state.value === 'idle' || state.value === 'over') {
+    start()
+    return
+  }
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+  doFlap(e.clientX - rect.left < rect.width / 2 ? -1 : 1)
+}
+
+const onKey = (e: KeyboardEvent) => {
+  if (e.key === 'ArrowLeft' || e.key === 'a') {
+    e.preventDefault()
+    if (state.value === 'running') doFlap(-1)
+    else start()
+  } else if (e.key === 'ArrowRight' || e.key === 'd') {
+    e.preventDefault()
+    if (state.value === 'running') doFlap(1)
+    else start()
+  } else if (e.key === ' ') {
+    e.preventDefault()
+    if (state.value !== 'running') start()
+  }
+}
+
+onMounted(() => {
+  try {
+    best.value = Number(localStorage.getItem(BEST_KEY)) || 0
+  } catch {
+    best.value = 0
+  }
+  reset()
+  draw()
+  window.addEventListener('keydown', onKey)
+})
+onBeforeUnmount(() => {
+  cancelAnimationFrame(raf)
+  window.removeEventListener('keydown', onKey)
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="600">
+    <GameToolbar title="Vertical Tunnel">
+      <template #intro>
+        Fly up through the tunnel. Tap the <strong>left</strong> or <strong>right</strong> side to
+        flap that way (arrow keys on desktop). Don't drift into the walls — it speeds up as you climb.
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Fly as far up the tunnel as you can without hitting a wall.</p>
+        <h3>Controls</h3>
+        <ul>
+          <li>Tap or click the left/right half of the screen to flap left/right.</li>
+          <li>Desktop: <span class="k">←</span>/<span class="k">→</span> (or A/D). <span class="k">Space</span> to start.</li>
+          <li>Between flaps you keep drifting, then slow — so tap in rhythm to steer.</li>
+        </ul>
+        <h3>Tips</h3>
+        <ul>
+          <li>Small, frequent taps steer more precisely than one big flap.</li>
+          <li>Look ahead to where the gap is drifting, not where it is now.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <div class="d-flex align-center mb-3">
+      <div class="text-h6">Distance: <span class="font-weight-bold">{{ score }}</span></div>
+      <v-spacer />
+      <div class="text-body-2 text-medium-emphasis">Best: {{ best }}</div>
+    </div>
+
+    <div ref="boardEl" class="stage" :style="{ width: displayW + 'px', height: displayH + 'px' }">
+      <canvas
+        ref="canvasEl"
+        class="canvas"
+        :style="{ width: displayW + 'px', height: displayH + 'px' }"
+        @pointerdown.prevent="onPointer"
+      />
+      <div v-if="state !== 'running'" class="overlay">
+        <template v-if="state === 'idle'">
+          <p class="text-h6 mb-2">Tap to fly</p>
+          <p class="text-caption text-medium-emphasis mb-3">Left/right side flaps that way</p>
+          <v-btn color="primary" variant="flat" @click="start">Start</v-btn>
+        </template>
+        <template v-else>
+          <p class="text-h5 mb-1">Crashed</p>
+          <p class="text-body-2 mb-3">
+            Distance {{ score }}<span v-if="score === best && score > 0"> — new best!</span>
+          </p>
+          <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="start">Fly again</v-btn>
+        </template>
+      </div>
+    </div>
+  </v-container>
+</template>
+
+<style scoped>
+.stage {
+  position: relative;
+  margin: 0 auto;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 0 40px rgba(56, 189, 248, 0.15);
+}
+.canvas {
+  display: block;
+  touch-action: none;
+}
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: rgba(2, 6, 23, 0.7);
+  backdrop-filter: blur(2px);
+}
+</style>

--- a/src/views/WallJumpView.vue
+++ b/src/views/WallJumpView.vue
@@ -1,0 +1,328 @@
+<script setup lang="ts">
+/**
+ * Ninja Climb — cling to a wall, hold to charge, release to leap to the opposite
+ * wall. Hold longer to jump higher. Spikes jut from the walls (land on one and
+ * you're done) and rising lava chases you up, so keep climbing. Canvas-rendered;
+ * physics/hazards come from services/wallJump. Score is height reached.
+ */
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import GameToolbar from '@/components/GameToolbar.vue'
+import { useSquareFit } from '@/composables/useSquareFit'
+import {
+  MAX_CHARGE_MS,
+  SPIKE_SPACING,
+  hitsSpike,
+  initialNinja,
+  jump,
+  spikeAt,
+  stepNinja,
+  type NinjaState,
+} from '@/services/wallJump'
+
+const { el: boardEl, px: boardPx } = useSquareFit(150)
+const displayW = computed(() => Math.round(boardPx.value * 0.66))
+const displayH = computed(() => boardPx.value)
+
+const BEST_KEY = 'walljump-best'
+const WALL_THICK = 0.1 // fraction of width
+const UNITS_VISIBLE = 6 // climb units shown vertically
+const NINJA_SCREEN = 0.62 // ninja's vertical screen position
+
+const canvasEl = ref<HTMLCanvasElement | null>(null)
+const state = ref<'idle' | 'running' | 'over'>('idle')
+const best = ref(0)
+const chargeMs = ref(0)
+
+let ninja: NinjaState = initialNinja()
+let seed = 1
+let maxY = 0
+let dangerY = -4
+let charging = false
+let chargeStart = 0
+let raf = 0
+let lastTs = 0
+
+const score = computed(() => Math.max(0, Math.round(maxY * 10)))
+
+const reset = () => {
+  ninja = initialNinja()
+  seed = (Math.floor(Math.random() * 0xffffffff) || 1) >>> 0
+  maxY = 0
+  dangerY = -4
+  charging = false
+  chargeMs.value = 0
+}
+
+const gameOver = () => {
+  state.value = 'over'
+  cancelAnimationFrame(raf)
+  raf = 0
+  charging = false
+  if (score.value > best.value) {
+    best.value = score.value
+    try {
+      localStorage.setItem(BEST_KEY, String(best.value))
+    } catch {
+      // ignore
+    }
+  }
+}
+
+const yToScreen = (worldY: number, cameraY: number, H: number, unit: number) =>
+  NINJA_SCREEN * H - (worldY - cameraY) * unit
+
+const draw = () => {
+  const canvas = canvasEl.value
+  if (!canvas) return
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  const dpr = window.devicePixelRatio || 1
+  const W = displayW.value
+  const H = displayH.value
+  if (canvas.width !== W * dpr || canvas.height !== H * dpr) {
+    canvas.width = W * dpr
+    canvas.height = H * dpr
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.fillStyle = '#0b1020'
+  ctx.fillRect(0, 0, W, H)
+
+  const unit = H / UNITS_VISIBLE
+  const cameraY = ninja.y
+  const wt = WALL_THICK * W
+
+  // Walls
+  ctx.fillStyle = '#1e293b'
+  ctx.fillRect(0, 0, wt, H)
+  ctx.fillRect(W - wt, 0, wt, H)
+
+  // Spikes near the camera
+  const lo = Math.floor((cameraY - 2.5) / SPIKE_SPACING) - 1
+  const hi = Math.ceil((cameraY + 4) / SPIKE_SPACING) + 1
+  ctx.fillStyle = '#94a3b8'
+  for (let i = Math.max(0, lo); i <= hi; i += 1) {
+    const spike = spikeAt(seed, i)
+    const sy = yToScreen(spike.y, cameraY, H, unit)
+    if (sy < -20 || sy > H + 20) continue
+    const halfPx = spike.half * unit
+    if (spike.side === -1) {
+      ctx.beginPath()
+      ctx.moveTo(wt, sy - halfPx)
+      ctx.lineTo(wt + halfPx * 1.1, sy)
+      ctx.lineTo(wt, sy + halfPx)
+      ctx.closePath()
+      ctx.fill()
+    } else {
+      ctx.beginPath()
+      ctx.moveTo(W - wt, sy - halfPx)
+      ctx.lineTo(W - wt - halfPx * 1.1, sy)
+      ctx.lineTo(W - wt, sy + halfPx)
+      ctx.closePath()
+      ctx.fill()
+    }
+  }
+
+  // Rising lava
+  const lavaScreen = yToScreen(dangerY, cameraY, H, unit)
+  if (lavaScreen < H) {
+    const grad = ctx.createLinearGradient(0, lavaScreen, 0, H)
+    grad.addColorStop(0, 'rgba(239, 68, 68, 0.55)')
+    grad.addColorStop(1, 'rgba(127, 29, 29, 0.95)')
+    ctx.fillStyle = grad
+    ctx.fillRect(0, Math.max(0, lavaScreen), W, H - Math.max(0, lavaScreen))
+  }
+
+  // Ninja
+  const nx = ninja.x * W
+  const ny = yToScreen(ninja.y, cameraY, H, unit)
+  ctx.beginPath()
+  ctx.arc(nx, ny, 0.05 * W, 0, Math.PI * 2)
+  ctx.fillStyle = '#f8fafc'
+  ctx.shadowColor = '#38bdf8'
+  ctx.shadowBlur = 14
+  ctx.fill()
+  ctx.shadowBlur = 0
+
+  // Charge meter (while holding, grounded)
+  if (charging && !ninja.airborne) {
+    const t = Math.min(1, chargeMs.value / MAX_CHARGE_MS)
+    const barH = 0.18 * H * t
+    ctx.fillStyle = '#22d3ee'
+    ctx.fillRect(nx - 4, ny - 0.05 * W - barH - 6, 8, barH)
+  }
+}
+
+const tick = (ts: number) => {
+  if (state.value !== 'running') return
+  const dt = lastTs ? Math.min(48, ts - lastTs) : 16
+  lastTs = ts
+
+  if (charging && !ninja.airborne) chargeMs.value = ts - chargeStart
+
+  ninja = stepNinja(ninja, dt)
+  if (ninja.y > maxY) maxY = ninja.y
+
+  // Rising hazard accelerates as you climb.
+  const dangerSpeed = 0.4 + Math.min(1.3, maxY * 0.02)
+  dangerY += (dangerSpeed * dt) / 1000
+
+  if (!ninja.airborne && hitsSpike(ninja, seed)) {
+    draw()
+    gameOver()
+    return
+  }
+  if (ninja.y <= dangerY) {
+    draw()
+    gameOver()
+    return
+  }
+  draw()
+  raf = requestAnimationFrame(tick)
+}
+
+const start = () => {
+  reset()
+  state.value = 'running'
+  lastTs = 0
+  cancelAnimationFrame(raf)
+  raf = requestAnimationFrame(tick)
+}
+
+const beginCharge = (ts: number) => {
+  if (state.value !== 'running') {
+    start()
+  }
+  if (!ninja.airborne) {
+    charging = true
+    chargeStart = ts
+    chargeMs.value = 0
+  }
+}
+const releaseCharge = (ts: number) => {
+  if (state.value !== 'running' || !charging) return
+  charging = false
+  if (!ninja.airborne) {
+    ninja = jump(ninja, ts - chargeStart)
+    chargeMs.value = 0
+  }
+}
+
+const onPointerDown = (e: PointerEvent) => beginCharge(e.timeStamp)
+const onPointerUp = (e: PointerEvent) => releaseCharge(e.timeStamp)
+
+const onKeyDown = (e: KeyboardEvent) => {
+  if (e.key === ' ' && !e.repeat) {
+    e.preventDefault()
+    beginCharge(e.timeStamp)
+  }
+}
+const onKeyUp = (e: KeyboardEvent) => {
+  if (e.key === ' ') {
+    e.preventDefault()
+    releaseCharge(e.timeStamp)
+  }
+}
+
+watch([displayW, displayH], () => {
+  if (state.value !== 'running') draw()
+})
+
+onMounted(() => {
+  try {
+    best.value = Number(localStorage.getItem(BEST_KEY)) || 0
+  } catch {
+    best.value = 0
+  }
+  reset()
+  draw()
+  window.addEventListener('keydown', onKeyDown)
+  window.addEventListener('keyup', onKeyUp)
+})
+onBeforeUnmount(() => {
+  cancelAnimationFrame(raf)
+  window.removeEventListener('keydown', onKeyDown)
+  window.removeEventListener('keyup', onKeyUp)
+})
+</script>
+
+<template>
+  <v-container class="py-6" max-width="600">
+    <GameToolbar title="Ninja Climb">
+      <template #intro>
+        Cling to a wall, <strong>hold</strong> to charge, and release to leap to the other wall —
+        hold longer to jump higher. Dodge the spikes and outrun the rising lava. Hold Space on desktop.
+      </template>
+      <template #info>
+        <h3>Goal</h3>
+        <p>Climb as high as you can, wall to wall, without landing on a spike or letting the lava catch you.</p>
+        <h3>Controls</h3>
+        <ul>
+          <li>Press and hold anywhere (or <span class="k">Space</span>) to charge a jump.</li>
+          <li>Release to leap to the opposite wall — a longer hold jumps higher.</li>
+        </ul>
+        <h3>Tips</h3>
+        <ul>
+          <li>Judge your charge so you land above the next spike, not into it.</li>
+          <li>The lava speeds up the higher you get — don't dawdle on a wall.</li>
+        </ul>
+      </template>
+    </GameToolbar>
+
+    <div class="d-flex align-center mb-3">
+      <div class="text-h6">Height: <span class="font-weight-bold">{{ score }}</span></div>
+      <v-spacer />
+      <div class="text-body-2 text-medium-emphasis">Best: {{ best }}</div>
+    </div>
+
+    <div ref="boardEl" class="stage" :style="{ width: displayW + 'px', height: displayH + 'px' }">
+      <canvas
+        ref="canvasEl"
+        class="canvas"
+        :style="{ width: displayW + 'px', height: displayH + 'px' }"
+        @pointerdown.prevent="onPointerDown"
+        @pointerup.prevent="onPointerUp"
+        @pointerleave="onPointerUp"
+      />
+      <div v-if="state !== 'running'" class="overlay">
+        <template v-if="state === 'idle'">
+          <p class="text-h6 mb-2">Hold to charge, release to jump</p>
+          <v-btn color="primary" variant="flat" @click="start">Start</v-btn>
+        </template>
+        <template v-else>
+          <p class="text-h5 mb-1">Caught!</p>
+          <p class="text-body-2 mb-3">
+            Height {{ score }}<span v-if="score === best && score > 0"> — new best!</span>
+          </p>
+          <v-btn color="primary" variant="flat" prepend-icon="mdi-restart" @click="start">Climb again</v-btn>
+        </template>
+      </div>
+    </div>
+  </v-container>
+</template>
+
+<style scoped>
+.stage {
+  position: relative;
+  margin: 0 auto;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 0 40px rgba(56, 189, 248, 0.15);
+}
+.canvas {
+  display: block;
+  touch-action: none;
+}
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0 16px;
+  background: rgba(2, 6, 23, 0.7);
+  backdrop-filter: blur(2px);
+}
+</style>

--- a/src/views/WallJumpView.vue
+++ b/src/views/WallJumpView.vue
@@ -9,12 +9,15 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import GameToolbar from '@/components/GameToolbar.vue'
 import { useSquareFit } from '@/composables/useSquareFit'
 import {
+  GRAVITY,
   MAX_CHARGE_MS,
   SPIKE_SPACING,
   hitsSpike,
   initialNinja,
   jump,
+  predictTrajectory,
   spikeAt,
+  stepLava,
   stepNinja,
   type NinjaState,
 } from '@/services/wallJump'
@@ -37,11 +40,15 @@ let ninja: NinjaState = initialNinja()
 let seed = 1
 let maxY = 0
 let dangerY = -4
+let elapsedMs = 0 // run time, drives lava acceleration
 let cameraY = 0 // lags ninja.y so the jump arc is visible on screen
 let charging = false
 let chargeStart = 0
 let raf = 0
 let lastTs = 0
+let dying = false // playing the death fall before the game-over screen
+let deathMs = 0
+let deathVy = 0
 
 const score = computed(() => Math.max(0, Math.round(maxY * 10)))
 
@@ -50,9 +57,13 @@ const reset = () => {
   seed = (Math.floor(Math.random() * 0xffffffff) || 1) >>> 0
   maxY = 0
   dangerY = -4
+  elapsedMs = 0
   cameraY = 0
   charging = false
   chargeMs.value = 0
+  dying = false
+  deathMs = 0
+  deathVy = 0
 }
 
 const gameOver = () => {
@@ -72,6 +83,67 @@ const gameOver = () => {
 
 const yToScreen = (worldY: number, cameraY: number, H: number, unit: number) =>
   NINJA_SCREEN * H - (worldY - cameraY) * unit
+
+/**
+ * Draw a tiny stick-ninja at (cx, cy). `facing` is the wall it clings to
+ * (-1 left / +1 right); the figure leans away from that wall and reaches an arm
+ * toward it, so you can read which side it's on. `s` is the body scale in px.
+ */
+const drawNinja = (
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  s: number,
+  facing: -1 | 1,
+  airborne: boolean,
+) => {
+  const f = facing // +1 limbs reach right, -1 reach left
+  ctx.save()
+  ctx.translate(cx, cy)
+  ctx.strokeStyle = '#f8fafc'
+  ctx.fillStyle = '#f8fafc'
+  ctx.lineWidth = Math.max(1.5, s * 0.22)
+  ctx.lineCap = 'round'
+  ctx.lineJoin = 'round'
+  ctx.shadowColor = '#38bdf8'
+  ctx.shadowBlur = 10
+
+  const headR = s * 0.5
+  const headY = -s * 1.35
+  // Head
+  ctx.beginPath()
+  ctx.arc(0, headY, headR, 0, Math.PI * 2)
+  ctx.fill()
+  // Headband tail streaming away from the wall it faces
+  ctx.beginPath()
+  ctx.moveTo(-f * headR * 0.6, headY - headR * 0.2)
+  ctx.lineTo(-f * headR * 1.9, headY - headR * 0.6)
+  ctx.stroke()
+  // Body
+  const hipY = s * 0.55
+  ctx.beginPath()
+  ctx.moveTo(0, headY + headR)
+  ctx.lineTo(0, hipY)
+  ctx.stroke()
+  // Arms: one reaches toward the wall (to cling), one out for balance
+  const armY = -s * 0.35
+  ctx.beginPath()
+  ctx.moveTo(0, armY)
+  ctx.lineTo(f * s * 1.0, armY + (airborne ? -s * 0.5 : s * 0.15)) // wall-side arm
+  ctx.moveTo(0, armY)
+  ctx.lineTo(-f * s * 0.85, armY + s * 0.55) // trailing arm
+  ctx.stroke()
+  // Legs: wall-side leg tucked up when clinging, both trailing when airborne
+  ctx.beginPath()
+  ctx.moveTo(0, hipY)
+  ctx.lineTo(f * s * 0.7, hipY + (airborne ? s * 0.9 : s * 0.5))
+  ctx.moveTo(0, hipY)
+  ctx.lineTo(-f * s * 0.6, hipY + s * 1.0)
+  ctx.stroke()
+
+  ctx.shadowBlur = 0
+  ctx.restore()
+}
 
 const draw = () => {
   const canvas = canvasEl.value
@@ -133,30 +205,74 @@ const draw = () => {
     ctx.fillRect(0, Math.max(0, lavaScreen), W, H - Math.max(0, lavaScreen))
   }
 
-  // Ninja
   const nx = ninja.x * W
   const ny = yToScreen(ninja.y, cameraY, H, unit)
-  ctx.beginPath()
-  ctx.arc(nx, ny, 0.05 * W, 0, Math.PI * 2)
-  ctx.fillStyle = '#f8fafc'
-  ctx.shadowColor = '#38bdf8'
-  ctx.shadowBlur = 14
-  ctx.fill()
-  ctx.shadowBlur = 0
+
+  // Charge arc preview: a dashed predicted trajectory that grows with the hold.
+  if (charging && !ninja.airborne) {
+    const path = predictTrajectory(ninja, chargeMs.value)
+    if (path.length > 1) {
+      ctx.save()
+      ctx.strokeStyle = 'rgba(34, 211, 238, 0.85)'
+      ctx.lineWidth = 2
+      ctx.setLineDash([4, 6])
+      ctx.beginPath()
+      for (let i = 0; i < path.length; i += 1) {
+        const px = path[i].x * W
+        const py = yToScreen(path[i].y, cameraY, H, unit)
+        if (i === 0) ctx.moveTo(px, py)
+        else ctx.lineTo(px, py)
+      }
+      ctx.stroke()
+      ctx.setLineDash([])
+      // Landing marker at the end of the arc.
+      const end = path[path.length - 1]
+      ctx.fillStyle = 'rgba(34, 211, 238, 0.9)'
+      ctx.beginPath()
+      ctx.arc(end.x * W, yToScreen(end.y, cameraY, H, unit), 3.5, 0, Math.PI * 2)
+      ctx.fill()
+      ctx.restore()
+    }
+  }
+
+  // Ninja figure, oriented to the wall it clings to (or last leaned toward).
+  drawNinja(ctx, nx, ny, 0.05 * W, ninja.side, ninja.airborne || dying)
 
   // Charge meter (while holding, grounded)
   if (charging && !ninja.airborne) {
     const t = Math.min(1, chargeMs.value / MAX_CHARGE_MS)
     const barH = 0.18 * H * t
     ctx.fillStyle = '#22d3ee'
-    ctx.fillRect(nx - 4, ny - 0.05 * W - barH - 6, 8, barH)
+    ctx.fillRect(nx - 4, ny - 0.11 * W - barH - 6, 8, barH)
   }
+}
+
+// Detach the ninja and let it tumble down for a beat before the game-over card.
+const startDeath = () => {
+  dying = true
+  deathMs = 0
+  deathVy = 0
+  ninja = { ...ninja, airborne: true, vx: 0 }
 }
 
 const tick = (ts: number) => {
   if (state.value !== 'running') return
   const dt = lastTs ? Math.min(48, ts - lastTs) : 16
   lastTs = ts
+
+  if (dying) {
+    deathMs += dt
+    deathVy += (GRAVITY * dt) / 1000
+    ninja = { ...ninja, y: ninja.y - (deathVy * dt) / 1000 }
+    cameraY += (ninja.y - cameraY) * Math.min(1, (dt / 1000) * 4)
+    draw()
+    if (deathMs > 650) {
+      gameOver()
+      return
+    }
+    raf = requestAnimationFrame(tick)
+    return
+  }
 
   if (charging && !ninja.airborne) chargeMs.value = ts - chargeStart
 
@@ -165,13 +281,15 @@ const tick = (ts: number) => {
   // Ease the camera toward the ninja so the jump arc is visible before it recenters.
   cameraY += (ninja.y - cameraY) * Math.min(1, (dt / 1000) * 5)
 
-  // Rising hazard accelerates as you climb.
-  const dangerSpeed = 0.4 + Math.min(1.3, maxY * 0.02)
-  dangerY += (dangerSpeed * dt) / 1000
+  // Lava rises, accelerating the longer the run lasts.
+  elapsedMs += dt
+  dangerY = stepLava(dangerY, elapsedMs, dt)
 
-  if (!ninja.airborne && hitsSpike(ninja, seed)) {
+  // Fly into (or land on) a spike and the ninja falls to its death.
+  if (hitsSpike(ninja, seed)) {
+    startDeath()
     draw()
-    gameOver()
+    raf = requestAnimationFrame(tick)
     return
   }
   if (ninja.y <= dangerY) {

--- a/src/views/WallJumpView.vue
+++ b/src/views/WallJumpView.vue
@@ -37,6 +37,7 @@ let ninja: NinjaState = initialNinja()
 let seed = 1
 let maxY = 0
 let dangerY = -4
+let cameraY = 0 // lags ninja.y so the jump arc is visible on screen
 let charging = false
 let chargeStart = 0
 let raf = 0
@@ -49,6 +50,7 @@ const reset = () => {
   seed = (Math.floor(Math.random() * 0xffffffff) || 1) >>> 0
   maxY = 0
   dangerY = -4
+  cameraY = 0
   charging = false
   chargeMs.value = 0
 }
@@ -88,7 +90,6 @@ const draw = () => {
   ctx.fillRect(0, 0, W, H)
 
   const unit = H / UNITS_VISIBLE
-  const cameraY = ninja.y
   const wt = WALL_THICK * W
 
   // Walls
@@ -161,6 +162,8 @@ const tick = (ts: number) => {
 
   ninja = stepNinja(ninja, dt)
   if (ninja.y > maxY) maxY = ninja.y
+  // Ease the camera toward the ninja so the jump arc is visible before it recenters.
+  cameraY += (ninja.y - cameraY) * Math.min(1, (dt / 1000) * 5)
 
   // Rising hazard accelerates as you climb.
   const dangerSpeed = 0.4 + Math.min(1.3, maxY * 0.02)
@@ -281,7 +284,6 @@ onBeforeUnmount(() => {
         :style="{ width: displayW + 'px', height: displayH + 'px' }"
         @pointerdown.prevent="onPointerDown"
         @pointerup.prevent="onPointerUp"
-        @pointerleave="onPointerUp"
       />
       <div v-if="state !== 'running'" class="overlay">
         <template v-if="state === 'idle'">


### PR DESCRIPTION
Adds fourteen new games to the `/games` section, all built on the site's existing **unlimited-play, no-lockout** model (seedable / endlessly replayable). Each game is a pure, unit-tested logic module plus a Vuetify view using the shared `GameToolbar`.

## Games

**Puzzle / board / word**
| Game | Route | Highlights |
|------|-------|-----------|
| 2048 | `/2048` | Sliding-tile animation, undo, continue-after-win, best score |
| Tetris | `/tetris` | 7-bag, wall kicks, ghost, hold, next queue, lock delay, levels |
| Sudoku | `/sudoku` | Seeded unique puzzles (4 difficulties), notes, hints, bitmask solver |
| Nonogram | `/nonogram` | Row/col clue logic, drag-to-paint, X-marks, 3 sizes |
| Tango | `/tango` | Sun/Moon binary logic with =/× constraints |
| Nerdle | `/nerdle` | Wordle for equations, no-eval precedence evaluator |
| Memory | `/memory` | Flip-to-match + Simon, in one toggle |
| Connect 4 | `/connect-4` | Negamax AI (alpha-beta), 3 difficulties |

**Arcade** (from David's own concepts)
| Game | Route | Highlights |
|------|-------|-----------|
| Vertical Tunnel | `/tunnel` | Tap a side to flap; narrowing scrolling course |
| Ninja Climb | `/ninja-climb` | Hold-to-charge wall jumps; spikes + rising lava |
| Ball Bounce | `/ball-bounce` | Doodle-jump auto-bouncer with screen wrap |
| Count the Blocks | `/count-blocks` | Memory: tally the shapes that streamed past |
| Color from Memory | `/color-memory` | Recreate a flashed color; perceptual scoring |
| Mini Golf | `/mini-golf` | 9 seeded holes, pull-back-to-putt, wall banks |

## Approach

Every game is two commits: **add**, then a **code-review fix** commit. Each was reviewed with `/code-review` and the findings fixed. A sampling of real bugs caught:

- **2048**: pop keyframe animated `transform` (tile position), flinging merged tiles from the corner.
- **Sudoku**: first solver too slow → rewrote with incremental **bitmask constraints** (~100× faster).
- **Connect 4**: evaluation wasn't antisymmetric, quietly breaking negamax's zero-sum assumption.
- **Vertical Tunnel**: collision sampled the wrong row vs. what was drawn (phantom crashes).
- **Ninja Climb**: camera hard-locked to the ninja, hiding the jump arc (the core mechanic).
- **Count the Blocks**: same-lane pieces could overlap and be miscounted → separated into time slots.

## Tests

`vitest run` → **258 passed, 1 skipped** (pre-existing). Full `eslint .` clean; `vite build` green. Every game's logic module has a `.spec.ts`.

## Backlog

`GAMES_BACKLOG.md` tracks remaining ideas (Connections, Spelling Bee, Letter Boxed) and known follow-ups (Nonogram picture quality, Mini Golf hole-solvability checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)